### PR TITLE
Update janitor API cleanup endpoint to use GET method and add Vercel …

### DIFF
--- a/apps/server/src/janitor/withJanitorApi.ts
+++ b/apps/server/src/janitor/withJanitorApi.ts
@@ -25,19 +25,10 @@ export const withJanitorApi: Routes.Fn = ({ public: publicEndpoints }) => {
 
 	endpoints.openapi(
 		createRoute({
-			method: "post",
+			method: "get",
 			path: "/janitor/cleanup",
 			description: "Smaže z MinIO vše, co není v tabulce `upload`.",
 			operationId: "apiJanitorCleanup",
-			request: {
-				body: {
-					content: {
-						"application/json": {
-							schema: z.object({}),
-						},
-					},
-				},
-			},
 			responses: {
 				200: {
 					content: {

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://openapi.vercel.sh/vercel.json",
 	"crons": [
 		{
 			"path": "/api/public/janitor/cleanup",


### PR DESCRIPTION
…schema to configuration

- Changed the HTTP method for the janitor cleanup endpoint from POST to GET to align with RESTful practices.
- Added a schema reference to the Vercel configuration file for improved validation and documentation.