### PR TITLE
Update seed data generation parameters for improved performance

### DIFF
--- a/apps/app/src/@routes/$locale/dev/seed.tsx
+++ b/apps/app/src/@routes/$locale/dev/seed.tsx
@@ -107,12 +107,12 @@ export const Route = createFileRoute("/$locale/dev/seed")({
 					"Znojmo",
 				];
 
-				const concurrency = 16;
-				const limit = 2048;
-				const photos = 32;
+				const concurrency = 4;
+				const limit = 1000 * 5;
+				const photos = 64;
 
 				const uploadQueue = new PQueue({
-					concurrency: 4,
+					concurrency,
 				});
 
 				const uploadIds = await Promise.all<UploadDto>(
@@ -128,7 +128,7 @@ export const Route = createFileRoute("/$locale/dev/seed")({
 				);
 
 				const locationQueue = new PQueue({
-					concurrency: 4,
+					concurrency,
 				});
 
 				const locationIds = await Promise.all<string>(


### PR DESCRIPTION
- Reduced concurrency for photo uploads from 16 to 4 and adjusted the limit from 2048 to 5000, while increasing the number of photos from 32 to 64.
- Refactored PQueue initialization to utilize the updated concurrency variable, ensuring consistent configuration across upload and location ID processing.