### PR TITLE
Refactor toggle effects to remove userId from scope

### DIFF
--- a/apps/server/src/app/favourite/fx/favouriteToggleFx.ts
+++ b/apps/server/src/app/favourite/fx/favouriteToggleFx.ts
@@ -47,9 +47,7 @@ export const favouriteToggleFx = Effect.fn("favouriteToggleFx")(function* ({
 							where: {
 								id: listingId,
 							},
-							scope: {
-								userId,
-							},
+							scope: {},
 						});
 					});
 				},
@@ -71,9 +69,7 @@ export const favouriteToggleFx = Effect.fn("favouriteToggleFx")(function* ({
 							where: {
 								id: listingId,
 							},
-							scope: {
-								userId,
-							},
+							scope: {},
 						});
 					});
 				},

--- a/apps/server/src/app/flag/fx/flagToggleFx.ts
+++ b/apps/server/src/app/flag/fx/flagToggleFx.ts
@@ -45,9 +45,7 @@ export const flagToggleFx = Effect.fn("flagToggleFx")(function* ({
 							where: {
 								id: listingId,
 							},
-							scope: {
-								userId,
-							},
+							scope: {},
 						});
 					});
 				},
@@ -69,9 +67,7 @@ export const flagToggleFx = Effect.fn("flagToggleFx")(function* ({
 							where: {
 								id: listingId,
 							},
-							scope: {
-								userId,
-							},
+							scope: {},
 						});
 					});
 				},

--- a/apps/server/src/app/ignore/fx/ignoreToggleFx.ts
+++ b/apps/server/src/app/ignore/fx/ignoreToggleFx.ts
@@ -45,9 +45,7 @@ export const ignoreToggleFx = Effect.fn("ignoreToggleFx")(function* ({
 							where: {
 								id: listingId,
 							},
-							scope: {
-								userId,
-							},
+							scope: {},
 						});
 					});
 				},
@@ -69,9 +67,7 @@ export const ignoreToggleFx = Effect.fn("ignoreToggleFx")(function* ({
 							where: {
 								id: listingId,
 							},
-							scope: {
-								userId,
-							},
+							scope: {},
 						});
 					});
 				},


### PR DESCRIPTION
- Updated favouriteToggleFx, flagToggleFx, and ignoreToggleFx to eliminate the userId from the scope object, simplifying the function signatures.