### PR TITLE
Refactor sorting parameter from 'direction' to 'order' across multipl…

### DIFF
--- a/apps/app/src/@routes/$locale/buyer/feed/default.tsx
+++ b/apps/app/src/@routes/$locale/buyer/feed/default.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/$locale/buyer/feed/default")({
 				sort: [
 					{
 						field: "updatedAt",
-						direction: "desc",
+						order: "desc",
 					},
 				],
 			})

--- a/apps/app/src/@routes/$locale/dev/seed.tsx
+++ b/apps/app/src/@routes/$locale/dev/seed.tsx
@@ -249,43 +249,43 @@ export const Route = createFileRoute("/$locale/dev/seed")({
 			const sort = list([
 				{
 					field: "age",
-					direction: "desc",
+					order: "desc",
 				},
 				{
 					field: "price",
-					direction: "desc",
+					order: "desc",
 				},
 				{
 					field: "condition",
-					direction: "desc",
+					order: "desc",
 				},
 				{
 					field: "createdAt",
-					direction: "desc",
+					order: "desc",
 				},
 				{
 					field: "updatedAt",
-					direction: "desc",
+					order: "desc",
 				},
 				{
 					field: "age",
-					direction: "asc",
+					order: "asc",
 				},
 				{
 					field: "price",
-					direction: "asc",
+					order: "asc",
 				},
 				{
 					field: "condition",
-					direction: "asc",
+					order: "asc",
 				},
 				{
 					field: "createdAt",
-					direction: "asc",
+					order: "asc",
 				},
 				{
 					field: "updatedAt",
-					direction: "asc",
+					order: "asc",
 				},
 			] satisfies tListingSort[]);
 

--- a/apps/app/src/@routes/$locale/flow/buyer/feed/$id/favourite/list.tsx
+++ b/apps/app/src/@routes/$locale/flow/buyer/feed/$id/favourite/list.tsx
@@ -301,7 +301,7 @@ export const Route = createFileRoute("/$locale/flow/buyer/feed/$id/favourite/lis
 						sort: [
 							{
 								field: "expiresAt",
-								direction: "desc",
+								order: "desc",
 							},
 						],
 					}}

--- a/apps/app/src/@routes/$locale/flow/buyer/feed/$id/list.tsx
+++ b/apps/app/src/@routes/$locale/flow/buyer/feed/$id/list.tsx
@@ -360,7 +360,7 @@ export const Route = createFileRoute("/$locale/flow/buyer/feed/$id/list")({
 									: [
 											{
 												field: "createdAt",
-												direction: "desc",
+												order: "desc",
 											},
 										],
 								meta: {

--- a/apps/app/src/@routes/$locale/ui/buyer/favourite/list.tsx
+++ b/apps/app/src/@routes/$locale/ui/buyer/favourite/list.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute("/$locale/ui/buyer/favourite/list")({
 						sort: [
 							{
 								field: "createdAt",
-								direction: "desc",
+								order: "desc",
 							},
 						],
 					}}

--- a/apps/app/src/@routes/$locale/ui/buyer/feed/select.tsx
+++ b/apps/app/src/@routes/$locale/ui/buyer/feed/select.tsx
@@ -41,7 +41,7 @@ export const Route = createFileRoute("/$locale/ui/buyer/feed/select")({
 						sort: [
 							{
 								field: "createdAt",
-								direction: "desc",
+								order: "desc",
 							},
 						],
 					}}

--- a/apps/app/src/@routes/$locale/ui/buyer/message/list.tsx
+++ b/apps/app/src/@routes/$locale/ui/buyer/message/list.tsx
@@ -11,11 +11,11 @@ export const Route = createFileRoute("/$locale/ui/buyer/message/list")({
 						sort: [
 							{
 								field: "status",
-								direction: "asc",
+								order: "asc",
 							},
 							{
 								field: "createdAt",
-								direction: "desc",
+								order: "desc",
 							},
 						],
 					}}

--- a/apps/app/src/@routes/$locale/ui/seller/draft/list.tsx
+++ b/apps/app/src/@routes/$locale/ui/seller/draft/list.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute("/$locale/ui/seller/draft/list")({
 						sort: [
 							{
 								field: "createdAt",
-								direction: "asc",
+								order: "asc",
 							},
 						],
 					}}

--- a/apps/app/src/@routes/$locale/ui/seller/listing/my.tsx
+++ b/apps/app/src/@routes/$locale/ui/seller/listing/my.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/$locale/ui/seller/listing/my")({
 						sort: [
 							{
 								field: "createdAt",
-								direction: "desc",
+								order: "desc",
 							},
 						],
 					}}

--- a/apps/app/src/@routes/$locale/ui/seller/message/$listingId/list.tsx
+++ b/apps/app/src/@routes/$locale/ui/seller/message/$listingId/list.tsx
@@ -85,11 +85,11 @@ export const Route = createFileRoute("/$locale/ui/seller/message/$listingId/list
 							sort: [
 								{
 									field: "status",
-									direction: "asc",
+									order: "asc",
 								},
 								{
 									field: "createdAt",
-									direction: "desc",
+									order: "desc",
 								},
 							],
 						}}

--- a/apps/app/src/@routes/$locale/ui/seller/message/list.tsx
+++ b/apps/app/src/@routes/$locale/ui/seller/message/list.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute("/$locale/ui/seller/message/list")({
 						sort: [
 							{
 								field: "createdAt",
-								direction: "desc",
+								order: "desc",
 							},
 						],
 					}}

--- a/apps/app/src/app/@buyer-user/feed/service/feedCreateDefault.ts
+++ b/apps/app/src/app/@buyer-user/feed/service/feedCreateDefault.ts
@@ -32,19 +32,19 @@ export const feedCreateDefault = async ({ queryClient }: feedCreateDefault.Props
 			sort: [
 				{
 					field: "createdAt",
-					direction: "desc",
+					order: "desc",
 				},
 				{
 					field: "price",
-					direction: "asc",
+					order: "asc",
 				},
 				{
 					field: "condition",
-					direction: "desc",
+					order: "desc",
 				},
 				{
 					field: "age",
-					direction: "desc",
+					order: "desc",
 				},
 			],
 		},

--- a/apps/app/src/app/@buyer-user/feed/ui/button/CreateButton.tsx
+++ b/apps/app/src/app/@buyer-user/feed/ui/button/CreateButton.tsx
@@ -103,19 +103,19 @@ export const CreateButton: FC<CreateButton.Props> = ({
 									sort: [
 										{
 											field: "createdAt",
-											direction: "desc",
+											order: "desc",
 										},
 										{
 											field: "price",
-											direction: "asc",
+											order: "asc",
 										},
 										{
 											field: "condition",
-											direction: "desc",
+											order: "desc",
 										},
 										{
 											field: "age",
-											direction: "desc",
+											order: "desc",
 										},
 									],
 								},

--- a/apps/app/src/app/@buyer-user/listing/ui/ListingSortSelect.tsx
+++ b/apps/app/src/app/@buyer-user/listing/ui/ListingSortSelect.tsx
@@ -56,7 +56,7 @@ export const ListingSortSelect: FC<ListingSortSelect.Props> = ({ withGeo, state,
 									...state.value,
 									{
 										field: sortValue,
-										direction: "asc",
+										order: "asc",
 									} satisfies tListingSort,
 								]);
 								return;
@@ -68,13 +68,13 @@ export const ListingSortSelect: FC<ListingSortSelect.Props> = ({ withGeo, state,
 								return;
 							}
 
-							if (cur.direction === "asc") {
+							if (cur.order === "asc") {
 								const next = [
 									...state.value,
 								];
 								next[idx] = {
 									field: cur.field,
-									direction: "desc",
+									order: "desc",
 								} satisfies tListingSort;
 								state.set(next);
 								return;
@@ -83,7 +83,7 @@ export const ListingSortSelect: FC<ListingSortSelect.Props> = ({ withGeo, state,
 							state.set(state.value.filter((_, i) => i !== idx));
 						}}
 						{...uiSelectButton({
-							isSelected: Boolean(current?.direction),
+							isSelected: Boolean(current?.order),
 							ui: {
 								size: "default",
 							},
@@ -100,7 +100,7 @@ export const ListingSortSelect: FC<ListingSortSelect.Props> = ({ withGeo, state,
 							}}
 						>
 							<Tx
-								label={`Listing common sort value ${sortValue} - ${current?.direction ?? "unused"}`}
+								label={`Listing common sort value ${sortValue} - ${current?.order ?? "unused"}`}
 								ui={{
 									font: position ? "bold" : "normal",
 								}}

--- a/apps/app/src/app/@common/message/MessageList.tsx
+++ b/apps/app/src/app/@common/message/MessageList.tsx
@@ -103,7 +103,7 @@ export const MessageList: FC<MessageList.Props> = ({
 						sort: [
 							{
 								field: "createdAt",
-								direction: "asc",
+								order: "asc",
 							},
 						],
 					},

--- a/apps/app/src/app/@common/sort/ui/SortValue.tsx
+++ b/apps/app/src/app/@common/sort/ui/SortValue.tsx
@@ -6,7 +6,7 @@ import type { FC } from "react";
 export namespace SortValue {
 	export interface Sort {
 		field: string;
-		direction: string;
+		order: string;
 	}
 
 	export interface Props
@@ -35,7 +35,7 @@ export const SortValue: FC<SortValue.Props> = ({ sort, ...props }) => {
 			}))}
 			renderFn={(sortItem) => (
 				<Tx
-					label={`Listing common sort value ${sortItem.field} - ${sortItem.direction}`}
+					label={`Listing common sort value ${sortItem.field} - ${sortItem.order}`}
 					ui={{
 						tone: "secondary",
 					}}

--- a/apps/app/src/app/@seller/ui/SellerMenu.tsx
+++ b/apps/app/src/app/@seller/ui/SellerMenu.tsx
@@ -58,7 +58,7 @@ export const SellerMenu = ({ ui, ...props }: SellerMenu.Props) => {
 						sort: [
 							{
 								field: "updatedAt",
-								direction: "desc",
+								order: "desc",
 							},
 						],
 					}}

--- a/apps/app/src/app/@session/category/ui/category-select/ListContainer.tsx
+++ b/apps/app/src/app/@session/category/ui/category-select/ListContainer.tsx
@@ -39,7 +39,7 @@ export const ListContainer: FC<ListContainer.Props> = ({
 		sort: [
 			{
 				field: "sort",
-				direction: "asc",
+				order: "asc",
 			},
 		],
 	});

--- a/apps/server/src/@buyer-session/listing-event/db/withListingEventSourceSelectFx.ts
+++ b/apps/server/src/@buyer-session/listing-event/db/withListingEventSourceSelectFx.ts
@@ -19,7 +19,7 @@ export const withListingEventSourceSelectFx = Effect.fn("withListingEventSourceS
 
 		for (const item of sort ?? []) {
 			query = match(item.field)
-				.with("createdAt", () => query.orderBy("le.createdAt", item.direction))
+				.with("createdAt", () => query.orderBy("le.createdAt", item.order))
 				.exhaustive();
 		}
 

--- a/apps/server/src/@buyer-session/listing-event/schema/ListingEventSortSchema.ts
+++ b/apps/server/src/@buyer-session/listing-event/schema/ListingEventSortSchema.ts
@@ -10,7 +10,7 @@ export const ListingEventSortSchema = z
 			.openapi("ListingEventSortField", {
 				description: "Field of the listing event sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("ListingEventSort", {
 		description: "Sort object for listing event collection",

--- a/apps/server/src/@buyer-session/user-event/fx/userEventBuyerInfoFx.ts
+++ b/apps/server/src/@buyer-session/user-event/fx/userEventBuyerInfoFx.ts
@@ -502,15 +502,15 @@ export const userEventBuyerInfoFx = Effect.fn("userEventBuyerInfoFx")(function* 
 		sort: [
 			{
 				field: "group",
-				direction: "asc",
+				order: "asc",
 			},
 			{
 				field: "createdAt",
-				direction: "asc",
+				order: "asc",
 			},
 			{
 				field: "id",
-				direction: "asc",
+				order: "asc",
 			},
 		],
 	});

--- a/apps/server/src/@buyer-session/user-event/fx/userEventSellerInfoFx.ts
+++ b/apps/server/src/@buyer-session/user-event/fx/userEventSellerInfoFx.ts
@@ -528,15 +528,15 @@ export const userEventSellerInfoFx = Effect.fn("userEventSellerInfoFx")(function
 		sort: [
 			{
 				field: "group",
-				direction: "asc",
+				order: "asc",
 			},
 			{
 				field: "createdAt",
-				direction: "asc",
+				order: "asc",
 			},
 			{
 				field: "id",
-				direction: "asc",
+				order: "asc",
 			},
 		],
 	});

--- a/apps/server/src/@buyer-user/favourite/db/withFavouriteSourceSelectFx.ts
+++ b/apps/server/src/@buyer-user/favourite/db/withFavouriteSourceSelectFx.ts
@@ -20,7 +20,7 @@ export const withFavouriteSourceSelectFx = Effect.fn("withFavouriteSourceSelectF
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("f.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("f.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@buyer-user/favourite/schema/FavouriteSortSchema.ts
+++ b/apps/server/src/@buyer-user/favourite/schema/FavouriteSortSchema.ts
@@ -10,7 +10,7 @@ export const FavouriteSortSchema = z
 			.openapi("FavouriteSortField", {
 				description: "Field of the favourite sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("FavouriteSort", {
 		description: "Sort object for favourite collection",

--- a/apps/server/src/@buyer-user/feed/db/withFeedSourceSelectFx.ts
+++ b/apps/server/src/@buyer-user/feed/db/withFeedSourceSelectFx.ts
@@ -20,8 +20,8 @@ export const withFeedSourceSelectFx = Effect.fn("withFeedSourceSelectFx")(functi
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("f.createdAt", item.direction))
-			.with("updatedAt", () => query.orderBy("f.updatedAt", item.direction))
+			.with("createdAt", () => query.orderBy("f.createdAt", item.order))
+			.with("updatedAt", () => query.orderBy("f.updatedAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@buyer-user/feed/schema/FeedSortSchema.ts
+++ b/apps/server/src/@buyer-user/feed/schema/FeedSortSchema.ts
@@ -11,7 +11,7 @@ export const FeedSortSchema = z
 			.openapi("FeedSortField", {
 				description: "Field of the feed sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("FeedSort", {
 		description: "Sort object for feed collection",

--- a/apps/server/src/@buyer-user/flag/db/withFlagSourceSelectFx.ts
+++ b/apps/server/src/@buyer-user/flag/db/withFlagSourceSelectFx.ts
@@ -20,7 +20,7 @@ export const withFlagSourceSelectFx = Effect.fn("withFlagSourceSelectFx")(functi
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("f.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("f.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@buyer-user/flag/schema/FlagSortSchema.ts
+++ b/apps/server/src/@buyer-user/flag/schema/FlagSortSchema.ts
@@ -10,7 +10,7 @@ export const FlagSortSchema = z
 			.openapi("FlagSortField", {
 				description: "Field of the flag sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.strip()
 	.openapi("FlagSort", {

--- a/apps/server/src/@buyer-user/ignore/db/withIgnoreSourceSelectFx.ts
+++ b/apps/server/src/@buyer-user/ignore/db/withIgnoreSourceSelectFx.ts
@@ -20,7 +20,7 @@ export const withIgnoreSourceSelectFx = Effect.fn("withIgnoreSourceSelectFx")(fu
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("i.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("i.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@buyer-user/ignore/schema/IgnoreSortSchema.ts
+++ b/apps/server/src/@buyer-user/ignore/schema/IgnoreSortSchema.ts
@@ -10,7 +10,7 @@ export const IgnoreSortSchema = z
 			.openapi("IgnoreSortField", {
 				description: "Field of the ignore sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("IgnoreSort", {
 		description: "Sort object for ignore collection",

--- a/apps/server/src/@buyer-user/listing/db/withListingSourceSelectFx.ts
+++ b/apps/server/src/@buyer-user/listing/db/withListingSourceSelectFx.ts
@@ -27,12 +27,12 @@ export const withListingSourceSelectFx = Effect.fn("withListingSourceSelectFx")(
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("price", () => query.orderBy("l.price", item.direction))
-			.with("condition", () => query.orderBy("l.condition", item.direction))
-			.with("age", () => query.orderBy("l.age", item.direction))
-			.with("createdAt", () => query.orderBy("l.createdAt", item.direction))
-			.with("updatedAt", () => query.orderBy("l.updatedAt", item.direction))
-			.with("expiresAt", () => query.orderBy("l.expiresAt", item.direction))
+			.with("price", () => query.orderBy("l.price", item.order))
+			.with("condition", () => query.orderBy("l.condition", item.order))
+			.with("age", () => query.orderBy("l.age", item.order))
+			.with("createdAt", () => query.orderBy("l.createdAt", item.order))
+			.with("updatedAt", () => query.orderBy("l.updatedAt", item.order))
+			.with("expiresAt", () => query.orderBy("l.expiresAt", item.order))
 			.with("geo", () => {
 				if (!meta?.latLon) {
 					return query;
@@ -44,7 +44,7 @@ export const withListingSourceSelectFx = Effect.fn("withListingSourceSelectFx")(
 						sql`${eb.ref("loc.geo")} <-> ST_SetSRID(ST_MakePoint(${eb.val(
 							lon,
 						)}, ${eb.val(lat)}), 4326)`,
-					item.direction,
+					item.order,
 				);
 			})
 			.exhaustive();

--- a/apps/server/src/@buyer-user/listing/schema/ListingSortSchema.ts
+++ b/apps/server/src/@buyer-user/listing/schema/ListingSortSchema.ts
@@ -16,7 +16,7 @@ export const ListingSortSchema = z
 			.openapi("ListingSortField", {
 				description: "Field of the listing sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("ListingSort", {
 		description: "Sort object for listing collection",

--- a/apps/server/src/@buyer-user/transaction/db/withTransactionSourceSelectFx.ts
+++ b/apps/server/src/@buyer-user/transaction/db/withTransactionSourceSelectFx.ts
@@ -37,9 +37,9 @@ export const withTransactionSourceSelectFx = Effect.fn("withTransactionSourceSel
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("lt.createdAt", item.direction))
-			.with("updatedAt", () => query.orderBy("lt.updatedAt", item.direction))
-			.with("expiresAt", () => query.orderBy("lt.expiresAt", item.direction))
+			.with("createdAt", () => query.orderBy("lt.createdAt", item.order))
+			.with("updatedAt", () => query.orderBy("lt.updatedAt", item.order))
+			.with("expiresAt", () => query.orderBy("lt.expiresAt", item.order))
 			.with("status", () =>
 				query.orderBy(
 					(eb) =>
@@ -63,7 +63,7 @@ export const withTransactionSourceSelectFx = Effect.fn("withTransactionSourceSel
 							.then(70)
 							.else(999)
 							.end(),
-					item.direction,
+					item.order,
 				),
 			)
 			.exhaustive();

--- a/apps/server/src/@common/transaction/schema/TransactionSortSchema.ts
+++ b/apps/server/src/@common/transaction/schema/TransactionSortSchema.ts
@@ -13,7 +13,7 @@ export const TransactionSortSchema = z
 			.openapi("TransactionSortField", {
 				description: "Field of the transaction sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("TransactionSort", {
 		description: "Sort object for transaction collection",

--- a/apps/server/src/@common/user-event/db/withUserEventSourceSelectFx.ts
+++ b/apps/server/src/@common/user-event/db/withUserEventSourceSelectFx.ts
@@ -20,9 +20,9 @@ export const withUserEventSourceSelectFx = Effect.fn("withUserEventSourceSelectF
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("ue.createdAt", item.direction))
-			.with("group", () => query.orderBy("ue.group", item.direction))
-			.with("id", () => query.orderBy("ue.id", item.direction))
+			.with("createdAt", () => query.orderBy("ue.createdAt", item.order))
+			.with("group", () => query.orderBy("ue.group", item.order))
+			.with("id", () => query.orderBy("ue.id", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@common/user-event/schema/UserEventSortSchema.ts
+++ b/apps/server/src/@common/user-event/schema/UserEventSortSchema.ts
@@ -12,7 +12,7 @@ export const UserEventSortSchema = z
 			.openapi("UserEventSortField", {
 				description: "Field of the user event sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("UserEventSort", {
 		description: "Sort object for user event collection",

--- a/apps/server/src/@public/seed/fx/interaction/t01_resolve.ts
+++ b/apps/server/src/@public/seed/fx/interaction/t01_resolve.ts
@@ -59,7 +59,7 @@ export const t01_resolve = Effect.fn("t01_resolve")(function* ({
 			sort: [
 				{
 					field: "createdAt",
-					direction: "desc",
+					order: "desc",
 				},
 			],
 			scope: {},

--- a/apps/server/src/@public/seed/fx/interaction/t02_buyerReaction.ts
+++ b/apps/server/src/@public/seed/fx/interaction/t02_buyerReaction.ts
@@ -41,7 +41,7 @@ export const t02_buyerReaction = Effect.fn("t02_buyerReaction")(function* ({
 			sort: [
 				{
 					field: "createdAt",
-					direction: "desc",
+					order: "desc",
 				},
 			],
 			scope: {},

--- a/apps/server/src/@public/seed/fx/interaction/t03_sellerReaction.ts
+++ b/apps/server/src/@public/seed/fx/interaction/t03_sellerReaction.ts
@@ -59,7 +59,7 @@ export const t03_sellerReaction = Effect.fn("t03_sellerReaction")(function* ({
 			sort: [
 				{
 					field: "createdAt",
-					direction: "desc",
+					order: "desc",
 				},
 			],
 			scope: {},

--- a/apps/server/src/@public/seed/fx/interaction/t04_buyerFinish.ts
+++ b/apps/server/src/@public/seed/fx/interaction/t04_buyerFinish.ts
@@ -44,7 +44,7 @@ export const t04_buyerFinish = Effect.fn("t04_buyerFinish")(function* ({
 			sort: [
 				{
 					field: "createdAt",
-					direction: "desc",
+					order: "desc",
 				},
 			],
 			scope: {},

--- a/apps/server/src/@public/seed/fx/listingOfFx.ts
+++ b/apps/server/src/@public/seed/fx/listingOfFx.ts
@@ -47,7 +47,7 @@ export const listingOfFx = Effect.fn("listingOfFx")(function* ({
 			[
 				{
 					field: "age",
-					direction: list([
+					order: list([
 						"asc",
 						"desc",
 					]),
@@ -56,7 +56,7 @@ export const listingOfFx = Effect.fn("listingOfFx")(function* ({
 			[
 				{
 					field: "price",
-					direction: list([
+					order: list([
 						"asc",
 						"desc",
 					]),
@@ -65,7 +65,7 @@ export const listingOfFx = Effect.fn("listingOfFx")(function* ({
 			[
 				{
 					field: "createdAt",
-					direction: list([
+					order: list([
 						"asc",
 						"desc",
 					]),

--- a/apps/server/src/@seller-user/draft/db/withDraftSourceSelectFx.ts
+++ b/apps/server/src/@seller-user/draft/db/withDraftSourceSelectFx.ts
@@ -23,8 +23,8 @@ export const withDraftSourceSelectFx = Effect.fn("withDraftSourceSelectFx")(func
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("d.createdAt", item.direction))
-			.with("updatedAt", () => query.orderBy("d.updatedAt", item.direction))
+			.with("createdAt", () => query.orderBy("d.createdAt", item.order))
+			.with("updatedAt", () => query.orderBy("d.updatedAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@seller-user/draft/schema/DraftSortSchema.ts
+++ b/apps/server/src/@seller-user/draft/schema/DraftSortSchema.ts
@@ -11,7 +11,7 @@ export const DraftSortSchema = z
 			.openapi("DraftSortField", {
 				description: "Field of the draft sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("DraftSort", {
 		description: "Sort object for draft collection",

--- a/apps/server/src/@seller-user/listing/db/withListingSourceSelectFx.ts
+++ b/apps/server/src/@seller-user/listing/db/withListingSourceSelectFx.ts
@@ -23,12 +23,12 @@ export const withListingSourceSelectFx = Effect.fn("withListingSourceSelectFx")(
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("price", () => query.orderBy("l.price", item.direction))
-			.with("condition", () => query.orderBy("l.condition", item.direction))
-			.with("age", () => query.orderBy("l.age", item.direction))
-			.with("createdAt", () => query.orderBy("l.createdAt", item.direction))
-			.with("updatedAt", () => query.orderBy("l.updatedAt", item.direction))
-			.with("expiresAt", () => query.orderBy("l.expiresAt", item.direction))
+			.with("price", () => query.orderBy("l.price", item.order))
+			.with("condition", () => query.orderBy("l.condition", item.order))
+			.with("age", () => query.orderBy("l.age", item.order))
+			.with("createdAt", () => query.orderBy("l.createdAt", item.order))
+			.with("updatedAt", () => query.orderBy("l.updatedAt", item.order))
+			.with("expiresAt", () => query.orderBy("l.expiresAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@seller-user/listing/schema/ListingSortSchema.ts
+++ b/apps/server/src/@seller-user/listing/schema/ListingSortSchema.ts
@@ -15,7 +15,7 @@ export const ListingSortSchema = z
 			.openapi("ListingSortField", {
 				description: "Field of the listing sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("ListingSort", {
 		description: "Sort object for listing collection",

--- a/apps/server/src/@seller-user/transaction-listing/db/withTransactionListingSourceSelectFx.ts
+++ b/apps/server/src/@seller-user/transaction-listing/db/withTransactionListingSourceSelectFx.ts
@@ -25,7 +25,7 @@ export const withTransactionListingSourceSelectFx = Effect.fn(
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("l.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("l.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@seller-user/transaction-listing/schema/TransactionListingSortSchema.ts
+++ b/apps/server/src/@seller-user/transaction-listing/schema/TransactionListingSortSchema.ts
@@ -10,7 +10,7 @@ export const TransactionListingSortSchema = z
 			.openapi("TransactionListingSortField", {
 				description: "Field of the transaction-listing sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("TransactionListingSort", {
 		description: "Sort object for transaction-listing collection",

--- a/apps/server/src/@seller-user/transaction/db/withTransactionSourceSelectFx.ts
+++ b/apps/server/src/@seller-user/transaction/db/withTransactionSourceSelectFx.ts
@@ -37,9 +37,9 @@ export const withTransactionSourceSelectFx = Effect.fn("withTransactionSourceSel
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("lt.createdAt", item.direction))
-			.with("updatedAt", () => query.orderBy("lt.updatedAt", item.direction))
-			.with("expiresAt", () => query.orderBy("lt.expiresAt", item.direction))
+			.with("createdAt", () => query.orderBy("lt.createdAt", item.order))
+			.with("updatedAt", () => query.orderBy("lt.updatedAt", item.order))
+			.with("expiresAt", () => query.orderBy("lt.expiresAt", item.order))
 			.with("status", () =>
 				query.orderBy(
 					(eb) =>
@@ -63,7 +63,7 @@ export const withTransactionSourceSelectFx = Effect.fn("withTransactionSourceSel
 							.then(70)
 							.else(999)
 							.end(),
-					item.direction,
+					item.order,
 				),
 			)
 			.exhaustive();

--- a/apps/server/src/@session/category-miss/db/withCategoryMissSelectFx.ts
+++ b/apps/server/src/@session/category-miss/db/withCategoryMissSelectFx.ts
@@ -20,9 +20,9 @@ export const withCategoryMissSelectFx = Effect.fn("withCategoryMissSelectFx")(fu
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("category", () => query.orderBy("cm.category", item.direction))
-			.with("count", () => query.orderBy("cm.count", item.direction))
-			.with("updatedAt", () => query.orderBy("cm.updatedAt", item.direction))
+			.with("category", () => query.orderBy("cm.category", item.order))
+			.with("count", () => query.orderBy("cm.count", item.order))
+			.with("updatedAt", () => query.orderBy("cm.updatedAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@session/category-miss/schema/CategoryMissSortSchema.ts
+++ b/apps/server/src/@session/category-miss/schema/CategoryMissSortSchema.ts
@@ -12,7 +12,7 @@ export const CategoryMissSortSchema = z
 			.openapi("CategoryMissSortField", {
 				description: "Field for category miss sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.strip()
 	.openapi("CategoryMissSort", {

--- a/apps/server/src/@session/category/db/withCategorySourceSelectFx.ts
+++ b/apps/server/src/@session/category/db/withCategorySourceSelectFx.ts
@@ -20,9 +20,9 @@ export const withCategorySourceSelectFx = Effect.fn("withCategorySourceSelectFx"
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("group", () => query.orderBy("cat.group", item.direction))
-			.with("category", () => query.orderBy("cat.category", item.direction))
-			.with("sort", () => query.orderBy("cat.sort", item.direction))
+			.with("group", () => query.orderBy("cat.group", item.order))
+			.with("category", () => query.orderBy("cat.category", item.order))
+			.with("sort", () => query.orderBy("cat.sort", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@session/category/schema/CategorySortSchema.ts
+++ b/apps/server/src/@session/category/schema/CategorySortSchema.ts
@@ -12,7 +12,7 @@ export const CategorySortSchema = z
 			.openapi("CategorySortField", {
 				description: "Field of the category sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.strip()
 	.openapi("CategorySort", {

--- a/apps/server/src/@session/location/db/withLocationSelectFx.ts
+++ b/apps/server/src/@session/location/db/withLocationSelectFx.ts
@@ -20,10 +20,10 @@ export const withLocationSelectFx = Effect.fn("withLocationSelectFx")(function* 
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("confidence", () => query.orderBy("loc.confidence", item.direction))
-			.with("query", () => query.orderBy("loc.query", item.direction))
-			.with("country", () => query.orderBy("loc.country", item.direction))
-			.with("address", () => query.orderBy("loc.address", item.direction))
+			.with("confidence", () => query.orderBy("loc.confidence", item.order))
+			.with("query", () => query.orderBy("loc.query", item.order))
+			.with("country", () => query.orderBy("loc.country", item.order))
+			.with("address", () => query.orderBy("loc.address", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@session/location/fx/locationAutocompleteFx.ts
+++ b/apps/server/src/@session/location/fx/locationAutocompleteFx.ts
@@ -38,7 +38,7 @@ export const locationAutocompleteFx = Effect.fn("locationAutocompleteFx")(functi
 				sort: [
 					{
 						field: "confidence",
-						direction: "desc",
+						order: "desc",
 					},
 				],
 				cursor: {
@@ -107,7 +107,7 @@ export const locationAutocompleteFx = Effect.fn("locationAutocompleteFx")(functi
 				sort: [
 					{
 						field: "confidence",
-						direction: "desc",
+						order: "desc",
 					},
 				],
 				cursor: {

--- a/apps/server/src/@session/location/schema/LocationSortSchema.ts
+++ b/apps/server/src/@session/location/schema/LocationSortSchema.ts
@@ -13,7 +13,7 @@ export const LocationSortSchema = z
 			.openapi("LocationSortField", {
 				description: "Field for location sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.strip()
 	.openapi("LocationSort", {

--- a/apps/server/src/@session/transaction-status/db/withTransactionStatusSelectFx.ts
+++ b/apps/server/src/@session/transaction-status/db/withTransactionStatusSelectFx.ts
@@ -20,7 +20,7 @@ export const withTransactionStatusSelectFx = Effect.fn("withTransactionStatusSel
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@session/transaction-status/schema/TransactionStatusSortSchema.ts
+++ b/apps/server/src/@session/transaction-status/schema/TransactionStatusSortSchema.ts
@@ -10,7 +10,7 @@ export const TransactionStatusSortSchema = z
 			.openapi("TransactionStatusSortField", {
 				description: "Available sort fields for listing transaction status",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.strip()
 	.openapi("TransactionStatusSort", {

--- a/apps/server/src/@user/gallery-item/db/withGalleryItemSourceSelectFx.ts
+++ b/apps/server/src/@user/gallery-item/db/withGalleryItemSourceSelectFx.ts
@@ -20,8 +20,8 @@ export const withGalleryItemSourceSelectFx = Effect.fn("withGalleryItemSourceSel
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("sort", () => query.orderBy("gal_item.sort", item.direction))
-			.with("createdAt", () => query.orderBy("gal_item.createdAt", item.direction))
+			.with("sort", () => query.orderBy("gal_item.sort", item.order))
+			.with("createdAt", () => query.orderBy("gal_item.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/gallery-item/schema/GalleryItemSortSchema.ts
+++ b/apps/server/src/@user/gallery-item/schema/GalleryItemSortSchema.ts
@@ -11,7 +11,7 @@ export const GalleryItemSortSchema = z
 			.openapi("GalleryItemSortField", {
 				description: "Field of the gallery item sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("GalleryItemSort", {
 		description: "Sort object for gallery item collection",

--- a/apps/server/src/@user/gallery/db/withGallerySelectFx.ts
+++ b/apps/server/src/@user/gallery/db/withGallerySelectFx.ts
@@ -20,7 +20,7 @@ export const withGallerySelectFx = Effect.fn("withGallerySelectFx")(function* ({
 		sort: [
 			{
 				field: "sort",
-				direction: "asc",
+				order: "asc",
 			},
 		],
 	});

--- a/apps/server/src/@user/gallery/db/withGallerySourceSelectFx.ts
+++ b/apps/server/src/@user/gallery/db/withGallerySourceSelectFx.ts
@@ -20,7 +20,7 @@ export const withGallerySourceSelectFx = Effect.fn("withGallerySourceSelectFx")(
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("gal.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("gal.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/gallery/schema/GallerySortSchema.ts
+++ b/apps/server/src/@user/gallery/schema/GallerySortSchema.ts
@@ -10,7 +10,7 @@ export const GallerySortSchema = z
 			.openapi("GallerySortField", {
 				description: "Field of the gallery sort",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("GallerySort", {
 		description: "Sort object for gallery collection",

--- a/apps/server/src/@user/message-gallery/db/withMessageGallerySelectFx.ts
+++ b/apps/server/src/@user/message-gallery/db/withMessageGallerySelectFx.ts
@@ -45,7 +45,7 @@ export const withMessageGallerySelectFx = Effect.fn("withMessageGallerySelectFx"
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("mg.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("mg.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message-gallery/schema/MessageGallerySortSchema.ts
+++ b/apps/server/src/@user/message-gallery/schema/MessageGallerySortSchema.ts
@@ -10,7 +10,7 @@ export const MessageGallerySortSchema = z
 			.openapi("MessageGallerySortField", {
 				description: "Available sort fields for message gallery",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessageGallerySort", {
 		description: "Sort parameters for message gallery collection",

--- a/apps/server/src/@user/message-location/db/withMessageLocationSelectFx.ts
+++ b/apps/server/src/@user/message-location/db/withMessageLocationSelectFx.ts
@@ -41,7 +41,7 @@ export const withMessageLocationSelectFx = Effect.fn("withMessageLocationSelectF
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("ml.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("ml.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message-location/schema/MessageLocationSortSchema.ts
+++ b/apps/server/src/@user/message-location/schema/MessageLocationSortSchema.ts
@@ -10,7 +10,7 @@ export const MessageLocationSortSchema = z
 			.openapi("MessageLocationSortField", {
 				description: "Available sort fields for message location",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessageLocationSort", {
 		description: "Sort parameters for message location collection",

--- a/apps/server/src/@user/message-package/db/withMessagePackageSelectFx.ts
+++ b/apps/server/src/@user/message-package/db/withMessagePackageSelectFx.ts
@@ -36,7 +36,7 @@ export const withMessagePackageSelectFx = Effect.fn("withMessagePackageSelectFx"
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("mp.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("mp.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message-package/schema/MessagePackageSortSchema.ts
+++ b/apps/server/src/@user/message-package/schema/MessagePackageSortSchema.ts
@@ -10,7 +10,7 @@ export const MessagePackageSortSchema = z
 			.openapi("MessagePackageSortField", {
 				description: "Available sort fields for message package",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessagePackageSort", {
 		description: "Sort parameters for message package collection",

--- a/apps/server/src/@user/message-personal/db/withMessagePersonalSelectFx.ts
+++ b/apps/server/src/@user/message-personal/db/withMessagePersonalSelectFx.ts
@@ -41,7 +41,7 @@ export const withMessagePersonalSelectFx = Effect.fn("withMessagePersonalSelectF
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("mp.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("mp.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message-personal/schema/MessagePersonalSortSchema.ts
+++ b/apps/server/src/@user/message-personal/schema/MessagePersonalSortSchema.ts
@@ -10,7 +10,7 @@ export const MessagePersonalSortSchema = z
 			.openapi("MessagePersonalSortField", {
 				description: "Available sort fields for message personal collection",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessagePersonalSort", {
 		description: "Sort configuration for message personal collection",

--- a/apps/server/src/@user/message-system/db/withMessageSystemSelectFx.ts
+++ b/apps/server/src/@user/message-system/db/withMessageSystemSelectFx.ts
@@ -26,7 +26,7 @@ export const withMessageSystemSelectFx = Effect.fn("withMessageSystemSelectFx")(
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("ms.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("ms.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message-system/schema/MessageSystemSortSchema.ts
+++ b/apps/server/src/@user/message-system/schema/MessageSystemSortSchema.ts
@@ -10,7 +10,7 @@ export const MessageSystemSortSchema = z
 			.openapi("MessageSystemSortField", {
 				description: "Available sort fields for system message",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessageSystemSort", {
 		description: "Sort parameters for system message collection",

--- a/apps/server/src/@user/message-text/db/withMessageTextSelectFx.ts
+++ b/apps/server/src/@user/message-text/db/withMessageTextSelectFx.ts
@@ -36,7 +36,7 @@ export const withMessageTextSelectFx = Effect.fn("withMessageTextSelectFx")(func
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("mt.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("mt.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message-text/schema/MessageTextSortSchema.ts
+++ b/apps/server/src/@user/message-text/schema/MessageTextSortSchema.ts
@@ -10,7 +10,7 @@ export const MessageTextSortSchema = z
 			.openapi("MessageTextSortField", {
 				description: "Available sort fields for listing transaction message",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessageTextSort", {
 		description: "Sort parameters for listing transaction message collection",

--- a/apps/server/src/@user/message-thread-user/db/withMessageThreadUserSelectFx.ts
+++ b/apps/server/src/@user/message-thread-user/db/withMessageThreadUserSelectFx.ts
@@ -20,7 +20,7 @@ export const withMessageThreadUserSelectFx = Effect.fn("withMessageThreadUserSel
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("mtu.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("mtu.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message-thread-user/schema/MessageThreadUserSortSchema.ts
+++ b/apps/server/src/@user/message-thread-user/schema/MessageThreadUserSortSchema.ts
@@ -10,7 +10,7 @@ export const MessageThreadUserSortSchema = z
 			.openapi("MessageThreadUserSortField", {
 				description: "Available sort fields for message thread user",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessageThreadUserSort", {
 		description: "Sort parameters for message thread user collection",

--- a/apps/server/src/@user/message-thread/db/withMessageThreadSelectFx.ts
+++ b/apps/server/src/@user/message-thread/db/withMessageThreadSelectFx.ts
@@ -20,8 +20,8 @@ export const withMessageThreadSelectFx = Effect.fn("withMessageThreadSelectFx")(
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("mt.createdAt", item.direction))
-			.with("updatedAt", () => query.orderBy("mt.updatedAt", item.direction))
+			.with("createdAt", () => query.orderBy("mt.createdAt", item.order))
+			.with("updatedAt", () => query.orderBy("mt.updatedAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message-thread/schema/MessageThreadSortSchema.ts
+++ b/apps/server/src/@user/message-thread/schema/MessageThreadSortSchema.ts
@@ -11,7 +11,7 @@ export const MessageThreadSortSchema = z
 			.openapi("MessageThreadSortField", {
 				description: "Available sort fields for message thread",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessageThreadSort", {
 		description: "Sort parameters for message thread collection",

--- a/apps/server/src/@user/message/db/withMessageSourceSelectFx.ts
+++ b/apps/server/src/@user/message/db/withMessageSourceSelectFx.ts
@@ -109,8 +109,8 @@ export const withMessageSourceSelectFx = Effect.fn("withMessageSourceSelectFx")(
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("id", () => query.orderBy("msg.id", item.direction))
-			.with("createdAt", () => query.orderBy("msg.createdAt", item.direction))
+			.with("id", () => query.orderBy("msg.id", item.order))
+			.with("createdAt", () => query.orderBy("msg.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/message/schema/MessageSortSchema.ts
+++ b/apps/server/src/@user/message/schema/MessageSortSchema.ts
@@ -11,7 +11,7 @@ export const MessageSortSchema = z
 			.openapi("MessageSortField", {
 				description: "Available sort fields for message collection",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("MessageSort", {
 		description: "Sort parameters for message collection",

--- a/apps/server/src/@user/upload/db/withUploadSourceSelectFx.ts
+++ b/apps/server/src/@user/upload/db/withUploadSourceSelectFx.ts
@@ -20,7 +20,7 @@ export const withUploadSourceSelectFx = Effect.fn("withUploadSourceSelectFx")(fu
 
 	for (const item of sort ?? []) {
 		query = match(item.field)
-			.with("createdAt", () => query.orderBy("u.createdAt", item.direction))
+			.with("createdAt", () => query.orderBy("u.createdAt", item.order))
 			.exhaustive();
 	}
 

--- a/apps/server/src/@user/upload/schema/UploadSortSchema.ts
+++ b/apps/server/src/@user/upload/schema/UploadSortSchema.ts
@@ -10,7 +10,7 @@ export const UploadSortSchema = z
 			.openapi("UploadSortField", {
 				description: "Field for uploading a file",
 			}),
-		direction: OrderEnumSchema,
+		order: OrderEnumSchema,
 	})
 	.openapi("UploadSort", {
 		description: "Data for uploading a file",

--- a/packages/@zbav-se.me/sdk/src/api/buyer-user/schemas.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/buyer-user/schemas.gen.ts
@@ -144,13 +144,13 @@ export const sFavouriteSort = {
         field: {
             $ref: '#/components/schemas/FavouriteSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -1069,13 +1069,13 @@ export const sListingSort = {
         field: {
             $ref: '#/components/schemas/ListingSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -1298,13 +1298,13 @@ export const sFeedSort = {
         field: {
             $ref: '#/components/schemas/FeedSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -1606,13 +1606,13 @@ export const sFlagSort = {
         field: {
             $ref: '#/components/schemas/FlagSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -1823,13 +1823,13 @@ export const sIgnoreSort = {
         field: {
             $ref: '#/components/schemas/IgnoreSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -2107,13 +2107,13 @@ export const sTransactionSort = {
         field: {
             $ref: '#/components/schemas/TransactionSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 

--- a/packages/@zbav-se.me/sdk/src/api/buyer-user/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/buyer-user/types.gen.ts
@@ -141,7 +141,7 @@ export type tOrderEnum = typeof tOrderEnum[keyof typeof tOrderEnum];
  */
 export type tFavouriteSort = {
     field: tFavouriteSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -790,7 +790,7 @@ export type tListingSortField = typeof tListingSortField[keyof typeof tListingSo
  */
 export type tListingSort = {
     field: tListingSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -927,7 +927,7 @@ export type tFeedSortField = typeof tFeedSortField[keyof typeof tFeedSortField];
  */
 export type tFeedSort = {
     field: tFeedSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -1113,7 +1113,7 @@ export type tFlagSortField = typeof tFlagSortField[keyof typeof tFlagSortField];
  */
 export type tFlagSort = {
     field: tFlagSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -1293,7 +1293,7 @@ export type tIgnoreSortField = typeof tIgnoreSortField[keyof typeof tIgnoreSortF
  */
 export type tIgnoreSort = {
     field: tIgnoreSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -1497,7 +1497,7 @@ export type tTransactionSortField = typeof tTransactionSortField[keyof typeof tT
  */
 export type tTransactionSort = {
     field: tTransactionSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**

--- a/packages/@zbav-se.me/sdk/src/api/buyer-user/zod.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/buyer-user/zod.gen.ts
@@ -145,7 +145,7 @@ export type zOrderEnum = z.infer<typeof zOrderEnum>;
  */
 export const zFavouriteSort = z.object({
     field: zFavouriteSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for favourite collection'
 });
@@ -804,7 +804,7 @@ export type zListingSortField = z.infer<typeof zListingSortField>;
  */
 export const zListingSort = z.object({
     field: zListingSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for listing collection'
 });
@@ -961,7 +961,7 @@ export type zFeedSortField = z.infer<typeof zFeedSortField>;
  */
 export const zFeedSort = z.object({
     field: zFeedSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for feed collection'
 });
@@ -1181,7 +1181,7 @@ export type zFlagSortField = z.infer<typeof zFlagSortField>;
  */
 export const zFlagSort = z.object({
     field: zFlagSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for flag collection'
 });
@@ -1374,7 +1374,7 @@ export type zIgnoreSortField = z.infer<typeof zIgnoreSortField>;
  */
 export const zIgnoreSort = z.object({
     field: zIgnoreSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for ignore collection'
 });
@@ -1616,7 +1616,7 @@ export type zTransactionSortField = z.infer<typeof zTransactionSortField>;
  */
 export const zTransactionSort = z.object({
     field: zTransactionSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for transaction collection'
 });

--- a/packages/@zbav-se.me/sdk/src/api/seller-session/schemas.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/seller-session/schemas.gen.ts
@@ -404,13 +404,13 @@ export const sTransactionSort = {
         field: {
             $ref: '#/components/schemas/TransactionSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 

--- a/packages/@zbav-se.me/sdk/src/api/seller-session/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/seller-session/types.gen.ts
@@ -333,7 +333,7 @@ export type tOrderEnum = typeof tOrderEnum[keyof typeof tOrderEnum];
  */
 export type tTransactionSort = {
     field: tTransactionSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**

--- a/packages/@zbav-se.me/sdk/src/api/seller-session/zod.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/seller-session/zod.gen.ts
@@ -345,7 +345,7 @@ export type zOrderEnum = z.infer<typeof zOrderEnum>;
  */
 export const zTransactionSort = z.object({
     field: zTransactionSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for transaction collection'
 });

--- a/packages/@zbav-se.me/sdk/src/api/seller-user/schemas.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/seller-user/schemas.gen.ts
@@ -157,13 +157,13 @@ export const sDraftSort = {
         field: {
             $ref: '#/components/schemas/DraftSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -1259,13 +1259,13 @@ export const sListingSort = {
         field: {
             $ref: '#/components/schemas/ListingSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -1803,13 +1803,13 @@ export const sTransactionSort = {
         field: {
             $ref: '#/components/schemas/TransactionSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -2001,13 +2001,13 @@ export const sTransactionListingSort = {
         field: {
             $ref: '#/components/schemas/TransactionListingSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 

--- a/packages/@zbav-se.me/sdk/src/api/seller-user/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/seller-user/types.gen.ts
@@ -157,7 +157,7 @@ export type tOrderEnum = typeof tOrderEnum[keyof typeof tOrderEnum];
  */
 export type tDraftSort = {
     field: tDraftSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -766,7 +766,7 @@ export type tListingSortField = typeof tListingSortField[keyof typeof tListingSo
  */
 export type tListingSort = {
     field: tListingSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -1055,7 +1055,7 @@ export type tTransactionSortField = typeof tTransactionSortField[keyof typeof tT
  */
 export type tTransactionSort = {
     field: tTransactionSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -1199,7 +1199,7 @@ export type tTransactionListingSortField = typeof tTransactionListingSortField[k
  */
 export type tTransactionListingSort = {
     field: tTransactionListingSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**

--- a/packages/@zbav-se.me/sdk/src/api/seller-user/zod.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/seller-user/zod.gen.ts
@@ -157,7 +157,7 @@ export type zOrderEnum = z.infer<typeof zOrderEnum>;
  */
 export const zDraftSort = z.object({
     field: zDraftSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for draft collection'
 });
@@ -802,7 +802,7 @@ export type zListingSortField = z.infer<typeof zListingSortField>;
  */
 export const zListingSort = z.object({
     field: zListingSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for listing collection'
 });
@@ -1107,7 +1107,7 @@ export type zTransactionSortField = z.infer<typeof zTransactionSortField>;
  */
 export const zTransactionSort = z.object({
     field: zTransactionSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for transaction collection'
 });
@@ -1263,7 +1263,7 @@ export type zTransactionListingSortField = z.infer<typeof zTransactionListingSor
  */
 export const zTransactionListingSort = z.object({
     field: zTransactionListingSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for transaction-listing collection'
 });

--- a/packages/@zbav-se.me/sdk/src/api/session/schemas.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/session/schemas.gen.ts
@@ -171,13 +171,13 @@ export const sCategorySort = {
         field: {
             $ref: '#/components/schemas/CategorySortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -528,13 +528,13 @@ export const sLocationSort = {
         field: {
             $ref: '#/components/schemas/LocationSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 

--- a/packages/@zbav-se.me/sdk/src/api/session/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/session/types.gen.ts
@@ -178,7 +178,7 @@ export type tOrderEnum = typeof tOrderEnum[keyof typeof tOrderEnum];
  */
 export type tCategorySort = {
     field: tCategorySortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -436,7 +436,7 @@ export type tLocationSortField = typeof tLocationSortField[keyof typeof tLocatio
  */
 export type tLocationSort = {
     field: tLocationSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**

--- a/packages/@zbav-se.me/sdk/src/api/session/zod.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/session/zod.gen.ts
@@ -168,7 +168,7 @@ export type zOrderEnum = z.infer<typeof zOrderEnum>;
  */
 export const zCategorySort = z.object({
     field: zCategorySortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for category collection'
 });
@@ -432,7 +432,7 @@ export type zLocationSortField = z.infer<typeof zLocationSortField>;
  */
 export const zLocationSort = z.object({
     field: zLocationSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Data for location sort'
 });

--- a/packages/@zbav-se.me/sdk/src/api/user/schemas.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/user/schemas.gen.ts
@@ -171,13 +171,13 @@ export const sGallerySort = {
         field: {
             $ref: '#/components/schemas/GallerySortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -763,13 +763,13 @@ export const sMessageSort = {
         field: {
             $ref: '#/components/schemas/MessageSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 
@@ -986,13 +986,13 @@ export const sUploadSort = {
         field: {
             $ref: '#/components/schemas/UploadSortField'
         },
-        direction: {
+        order: {
             $ref: '#/components/schemas/OrderEnum'
         }
     },
     required: [
         'field',
-        'direction'
+        'order'
     ]
 } as const;
 

--- a/packages/@zbav-se.me/sdk/src/api/user/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/user/types.gen.ts
@@ -163,7 +163,7 @@ export type tOrderEnum = typeof tOrderEnum[keyof typeof tOrderEnum];
  */
 export type tGallerySort = {
     field: tGallerySortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -560,7 +560,7 @@ export type tMessageSortField = typeof tMessageSortField[keyof typeof tMessageSo
  */
 export type tMessageSort = {
     field: tMessageSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**
@@ -755,7 +755,7 @@ export type tUploadSortField = typeof tUploadSortField[keyof typeof tUploadSortF
  */
 export type tUploadSort = {
     field: tUploadSortField;
-    direction: tOrderEnum;
+    order: tOrderEnum;
 };
 
 /**

--- a/packages/@zbav-se.me/sdk/src/api/user/zod.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/user/zod.gen.ts
@@ -167,7 +167,7 @@ export type zOrderEnum = z.infer<typeof zOrderEnum>;
  */
 export const zGallerySort = z.object({
     field: zGallerySortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort object for gallery collection'
 });
@@ -591,7 +591,7 @@ export type zMessageSortField = z.infer<typeof zMessageSortField>;
  */
 export const zMessageSort = z.object({
     field: zMessageSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Sort parameters for message collection'
 });
@@ -803,7 +803,7 @@ export type zUploadSortField = z.infer<typeof zUploadSortField>;
  */
 export const zUploadSort = z.object({
     field: zUploadSortField,
-    direction: zOrderEnum
+    order: zOrderEnum
 }).register(z.globalRegistry, {
     description: 'Data for uploading a file'
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad API/contract rename across many endpoints and consumers; risk is mainly regressions where any remaining caller still sends `direction` and sorting gets ignored or requests fail validation.
> 
> **Overview**
> **Renames the sort parameter key from `direction` to `order` end-to-end** across the app, server, and generated SDK.
> 
> Client routes/components and seed utilities now send `sort: [{ field, order }]`, UI helpers (`ListingSortSelect`, `SortValue`) read/write `order`, and server query builders + zod/openapi schemas consume `order` when building `orderBy` clauses. The generated SDK schemas/types/zod validators were regenerated to reflect the new `order` property (including required-field changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc39242604950dd5ac68dfdbeba028da5e1b7cfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->