### PR TITLE
Refactor API error handling to replace 403 status codes with 404

### DIFF
--- a/apps/app/src/@routes/$locale/dev/seed.tsx
+++ b/apps/app/src/@routes/$locale/dev/seed.tsx
@@ -66,7 +66,9 @@ export namespace seedListings {
 
 const generateProsCons = (): string[] | null => {
 	const count = rangedom(0, 5);
-	if (count === 0) return null;
+	if (count === 0) {
+		return null;
+	}
 
 	const samples = [
 		"Výborný stav, jako nové",

--- a/apps/server/src/@buyer-session/listing-event/create.ts
+++ b/apps/server/src/@buyer-session/listing-event/create.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -6,6 +6,8 @@ import { listingEventCreateFx } from "~/@buyer-session/listing-event/fx/listingE
 import { ListingEventCreateSchema } from "~/@buyer-session/listing-event/schema/ListingEventCreateSchema";
 import { ListingEventSchema } from "~/@buyer-session/listing-event/schema/ListingEventSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -97,54 +99,20 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "TooManyRequests",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 429>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										429,
-									);
-								},
+								{ _tag: "TooManyRequests" },
+								() => c.json(noticeError(e), 429),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-session/listing-event/create.ts
+++ b/apps/server/src/@buyer-session/listing-event/create.ts
@@ -5,6 +5,7 @@ import { Effect, Match } from "effect";
 import { listingEventCreateFx } from "~/@buyer-session/listing-event/fx/listingEventCreateFx";
 import { ListingEventCreateSchema } from "~/@buyer-session/listing-event/schema/ListingEventCreateSchema";
 import { ListingEventSchema } from "~/@buyer-session/listing-event/schema/ListingEventSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -114,13 +115,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-session/listing/seller-info.ts
+++ b/apps/server/src/@buyer-session/listing/seller-info.ts
@@ -3,6 +3,7 @@ import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { listingGetSellerInfoFx } from "~/@buyer-session/listing/fx/listingGetSellerInfoFx";
 import { SellerInfoSchema } from "~/@buyer-session/listing/schema/SellerInfoSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -83,13 +84,7 @@ export const withSellerInfoApiFx = Effect.fn("withSellerInfoApiFx")(function* ()
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-session/listing/seller-info.ts
+++ b/apps/server/src/@buyer-session/listing/seller-info.ts
@@ -4,6 +4,7 @@ import { Effect, Match } from "effect";
 import { listingGetSellerInfoFx } from "~/@buyer-session/listing/fx/listingGetSellerInfoFx";
 import { SellerInfoSchema } from "~/@buyer-session/listing/schema/SellerInfoSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -84,7 +85,7 @@ export const withSellerInfoApiFx = Effect.fn("withSellerInfoApiFx")(function* ()
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -92,13 +93,7 @@ export const withSellerInfoApiFx = Effect.fn("withSellerInfoApiFx")(function* ()
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@buyer-user/favourite/collection.ts
+++ b/apps/server/src/@buyer-user/favourite/collection.ts
@@ -1,9 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { favouriteCollectionFx } from "~/@buyer-user/favourite/fx/favouriteCollectionFx";
 import { FavouriteItemSchema } from "~/@buyer-user/favourite/schema/FavouriteItemSchema";
 import { FavouriteQuerySchema } from "~/@buyer-user/favourite/schema/FavouriteQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -86,15 +87,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/favourite/count.ts
+++ b/apps/server/src/@buyer-user/favourite/count.ts
@@ -1,8 +1,9 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { favouriteCountFx } from "~/@buyer-user/favourite/fx/favouriteCountFx";
 import { FavouriteCountQuerySchema } from "~/@buyer-user/favourite/schema/FavouriteCountQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { CountSchema } from "~/schema/CountSchema";
@@ -74,15 +75,7 @@ export const withCountApiFx = Effect.fn("withCountApiFx")(function* () {
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/favourite/toggle.ts
+++ b/apps/server/src/@buyer-user/favourite/toggle.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -6,6 +6,8 @@ import { favouriteToggleFx } from "~/@buyer-user/favourite/fx/favouriteToggleFx"
 import { FavouriteToggleSchema } from "~/@buyer-user/favourite/schema/FavouriteToggleSchema";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -92,36 +94,20 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/favourite/toggle.ts
+++ b/apps/server/src/@buyer-user/favourite/toggle.ts
@@ -5,6 +5,7 @@ import { Effect, Match } from "effect";
 import { favouriteToggleFx } from "~/@buyer-user/favourite/fx/favouriteToggleFx";
 import { FavouriteToggleSchema } from "~/@buyer-user/favourite/schema/FavouriteToggleSchema";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -91,13 +92,7 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/feed-favourite/collection.ts
+++ b/apps/server/src/@buyer-user/feed-favourite/collection.ts
@@ -1,9 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { FeedQuerySchema } from "~/@buyer-user/feed/schema/FeedQuerySchema";
 import { feedFavouriteCollectionFx } from "~/@buyer-user/feed-favourite/fx/feedFavouriteCollectionFx";
 import { FeedFavouriteItemSchema } from "~/@buyer-user/feed-favourite/schema/FeedFavouriteItemSchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -89,15 +90,7 @@ export const withFeedFavouriteCollectionApiFx = Effect.fn("withFeedFavouriteColl
 									{
 										_tag: "ZodErrorFx",
 									},
-									({ zod }) => {
-										return c.json<NoticeSchema.Type, 500>(
-											{
-												type: "error",
-												message: z.prettifyError(zod),
-											},
-											500,
-										);
-									},
+									({ zod }) => c.json(noticeZodError(zod), 500),
 								),
 								Match.exhaustive,
 							),

--- a/apps/server/src/@buyer-user/feed-gallery/create.ts
+++ b/apps/server/src/@buyer-user/feed-gallery/create.ts
@@ -4,6 +4,7 @@ import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { feedGalleryCreateFx } from "~/@buyer-user/feed-gallery/fx/feedGalleryCreateFx";
 import { FeedGalleryCreateSchema } from "~/@buyer-user/feed-gallery/schema/FeedGalleryCreateSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { GallerySchema } from "~/@user/gallery/schema/GallerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
@@ -107,13 +108,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -121,13 +116,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/feed-gallery/create.ts
+++ b/apps/server/src/@buyer-user/feed-gallery/create.ts
@@ -45,14 +45,6 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -129,12 +121,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@buyer-user/feed-gallery/create.ts
+++ b/apps/server/src/@buyer-user/feed-gallery/create.ts
@@ -1,10 +1,12 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { feedGalleryCreateFx } from "~/@buyer-user/feed-gallery/fx/feedGalleryCreateFx";
 import { FeedGalleryCreateSchema } from "~/@buyer-user/feed-gallery/schema/FeedGalleryCreateSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { GallerySchema } from "~/@user/gallery/schema/GallerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
@@ -93,45 +95,25 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "AccessDeniedError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/feed/collection.ts
+++ b/apps/server/src/@buyer-user/feed/collection.ts
@@ -1,9 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { feedCollectionFx } from "~/@buyer-user/feed/fx/feedCollectionFx";
 import { FeedItemSchema } from "~/@buyer-user/feed/schema/FeedItemSchema";
 import { FeedQuerySchema } from "~/@buyer-user/feed/schema/FeedQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -85,15 +86,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/feed/count.ts
+++ b/apps/server/src/@buyer-user/feed/count.ts
@@ -1,8 +1,9 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { feedCountFx } from "~/@buyer-user/feed/fx/feedCountFx";
 import { FeedCountQuerySchema } from "~/@buyer-user/feed/schema/FeedCountQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { CountSchema } from "~/schema/CountSchema";
@@ -74,15 +75,7 @@ export const withCountApiFx = Effect.fn("withCountApiFx")(function* () {
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/feed/create.ts
+++ b/apps/server/src/@buyer-user/feed/create.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -6,6 +6,7 @@ import { feedCreateFx } from "~/@buyer-user/feed/fx/feedCreateFx";
 import { FeedCreateSchema } from "~/@buyer-user/feed/schema/FeedCreateSchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -84,23 +85,13 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/feed/create.ts
+++ b/apps/server/src/@buyer-user/feed/create.ts
@@ -5,6 +5,7 @@ import { Effect, Match } from "effect";
 import { feedCreateFx } from "~/@buyer-user/feed/fx/feedCreateFx";
 import { FeedCreateSchema } from "~/@buyer-user/feed/schema/FeedCreateSchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -84,13 +85,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/feed/delete.ts
+++ b/apps/server/src/@buyer-user/feed/delete.ts
@@ -1,10 +1,11 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { feedDeleteFx } from "~/@buyer-user/feed/fx/feedDeleteFx";
 import { FeedQuerySchema } from "~/@buyer-user/feed/schema/FeedQuerySchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -85,7 +86,7 @@ export const withDeleteApiFx = Effect.fn("withDeleteApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -93,13 +94,7 @@ export const withDeleteApiFx = Effect.fn("withDeleteApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@buyer-user/feed/delete.ts
+++ b/apps/server/src/@buyer-user/feed/delete.ts
@@ -4,6 +4,7 @@ import { Effect, Match } from "effect";
 import { feedDeleteFx } from "~/@buyer-user/feed/fx/feedDeleteFx";
 import { FeedQuerySchema } from "~/@buyer-user/feed/schema/FeedQuerySchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -84,13 +85,7 @@ export const withDeleteApiFx = Effect.fn("withDeleteApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/feed/fetch.ts
+++ b/apps/server/src/@buyer-user/feed/fetch.ts
@@ -1,10 +1,11 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { feedFetchFx } from "~/@buyer-user/feed/fx/feedFetchFx";
 import { FeedQuerySchema } from "~/@buyer-user/feed/schema/FeedQuerySchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -85,23 +86,13 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/feed/fetch.ts
+++ b/apps/server/src/@buyer-user/feed/fetch.ts
@@ -4,12 +4,14 @@ import { Effect, Match } from "effect";
 import { feedFetchFx } from "~/@buyer-user/feed/fx/feedFetchFx";
 import { FeedQuerySchema } from "~/@buyer-user/feed/schema/FeedQuerySchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
 
 export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 	const { buyerUserHono } = yield* RoutesContextFx;
+
 	buyerUserHono.openapi(
 		createRoute({
 			method: "post",
@@ -84,13 +86,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/feed/patch.ts
+++ b/apps/server/src/@buyer-user/feed/patch.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -6,6 +6,7 @@ import { feedPatchFx } from "~/@buyer-user/feed/fx/feedPatchFx";
 import { FeedPatchSchema } from "~/@buyer-user/feed/schema/FeedPatchSchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -87,7 +88,7 @@ export const withPatchApiFx = Effect.fn("withPatchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -95,13 +96,7 @@ export const withPatchApiFx = Effect.fn("withPatchApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@buyer-user/feed/patch.ts
+++ b/apps/server/src/@buyer-user/feed/patch.ts
@@ -5,6 +5,7 @@ import { Effect, Match } from "effect";
 import { feedPatchFx } from "~/@buyer-user/feed/fx/feedPatchFx";
 import { FeedPatchSchema } from "~/@buyer-user/feed/schema/FeedPatchSchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -86,13 +87,7 @@ export const withPatchApiFx = Effect.fn("withPatchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/flag/collection.ts
+++ b/apps/server/src/@buyer-user/flag/collection.ts
@@ -1,9 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { flagCollectionFx } from "~/@buyer-user/flag/fx/flagCollectionFx";
 import { FlagItemSchema } from "~/@buyer-user/flag/schema/FlagItemSchema";
 import { FlagQuerySchema } from "~/@buyer-user/flag/schema/FlagQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -85,15 +86,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/flag/count.ts
+++ b/apps/server/src/@buyer-user/flag/count.ts
@@ -1,8 +1,9 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { flagCountFx } from "~/@buyer-user/flag/fx/flagCountFx";
 import { FlagCountQuerySchema } from "~/@buyer-user/flag/schema/FlagCountQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { CountSchema } from "~/schema/CountSchema";
@@ -74,15 +75,7 @@ export const withCountApiFx = Effect.fn("withCountApiFx")(function* () {
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/flag/toggle.ts
+++ b/apps/server/src/@buyer-user/flag/toggle.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -6,6 +6,8 @@ import { flagToggleFx } from "~/@buyer-user/flag/fx/flagToggleFx";
 import { FlagToggleSchema } from "~/@buyer-user/flag/schema/FlagToggleSchema";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -91,37 +93,19 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/flag/toggle.ts
+++ b/apps/server/src/@buyer-user/flag/toggle.ts
@@ -5,6 +5,7 @@ import { Effect, Match } from "effect";
 import { flagToggleFx } from "~/@buyer-user/flag/fx/flagToggleFx";
 import { FlagToggleSchema } from "~/@buyer-user/flag/schema/FlagToggleSchema";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -105,13 +106,7 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/ignore/collection.ts
+++ b/apps/server/src/@buyer-user/ignore/collection.ts
@@ -1,9 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { ignoreCollectionFx } from "~/@buyer-user/ignore/fx/ignoreCollectionFx";
 import { IgnoreItemSchema } from "~/@buyer-user/ignore/schema/IgnoreItemSchema";
 import { IgnoreQuerySchema } from "~/@buyer-user/ignore/schema/IgnoreQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -85,15 +86,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/ignore/count.ts
+++ b/apps/server/src/@buyer-user/ignore/count.ts
@@ -1,8 +1,9 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { ignoreCountFx } from "~/@buyer-user/ignore/fx/ignoreCountFx";
 import { IgnoreCountQuerySchema } from "~/@buyer-user/ignore/schema/IgnoreCountQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { CountSchema } from "~/schema/CountSchema";
@@ -74,15 +75,7 @@ export const withCountApiFx = Effect.fn("withCountApiFx")(function* () {
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/ignore/toggle.ts
+++ b/apps/server/src/@buyer-user/ignore/toggle.ts
@@ -5,6 +5,7 @@ import { Effect, Match } from "effect";
 import { ignoreToggleFx } from "~/@buyer-user/ignore/fx/ignoreToggleFx";
 import { IgnoreToggleSchema } from "~/@buyer-user/ignore/schema/IgnoreToggleSchema";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -105,13 +106,7 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/ignore/toggle.ts
+++ b/apps/server/src/@buyer-user/ignore/toggle.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -6,6 +6,8 @@ import { ignoreToggleFx } from "~/@buyer-user/ignore/fx/ignoreToggleFx";
 import { IgnoreToggleSchema } from "~/@buyer-user/ignore/schema/IgnoreToggleSchema";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -91,37 +93,19 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/listing/collection.ts
+++ b/apps/server/src/@buyer-user/listing/collection.ts
@@ -1,9 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { listingCollectionFx } from "~/@buyer-user/listing/fx/listingCollectionFx";
 import { ListingItemSchema } from "~/@buyer-user/listing/schema/ListingItemSchema";
 import { ListingQuerySchema } from "~/@buyer-user/listing/schema/ListingQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -84,15 +85,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/listing/count.ts
+++ b/apps/server/src/@buyer-user/listing/count.ts
@@ -1,8 +1,9 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { listingCountFx } from "~/@buyer-user/listing/fx/listingCountFx";
 import { ListingCountQuerySchema } from "~/@buyer-user/listing/schema/ListingCountQuerySchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { CountSchema } from "~/schema/CountSchema";
@@ -73,15 +74,7 @@ export const withCountApiFx = Effect.fn("withCountApiFx")(function* () {
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/listing/fetch.ts
+++ b/apps/server/src/@buyer-user/listing/fetch.ts
@@ -4,6 +4,7 @@ import { Effect, Match } from "effect";
 import { listingFetchFx } from "~/@buyer-user/listing/fx/listingFetchFx";
 import { ListingQuerySchema } from "~/@buyer-user/listing/schema/ListingQuerySchema";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -83,13 +84,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/listing/fetch.ts
+++ b/apps/server/src/@buyer-user/listing/fetch.ts
@@ -1,10 +1,11 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { listingFetchFx } from "~/@buyer-user/listing/fx/listingFetchFx";
 import { ListingQuerySchema } from "~/@buyer-user/listing/schema/ListingQuerySchema";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -84,7 +85,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -92,13 +93,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@buyer-user/thumb/create.ts
+++ b/apps/server/src/@buyer-user/thumb/create.ts
@@ -5,6 +5,7 @@ import { Effect, Match } from "effect";
 import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
 import { thumbCreateFx } from "~/@buyer-user/thumb/fx/thumbCreateFx";
 import { ThumbCreateSchema } from "~/@buyer-user/thumb/schema/ThumbCreateSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -106,13 +107,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/thumb/create.ts
+++ b/apps/server/src/@buyer-user/thumb/create.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -6,6 +6,8 @@ import { ListingSchema } from "~/@buyer-user/listing/schema/ListingSchema";
 import { thumbCreateFx } from "~/@buyer-user/thumb/fx/thumbCreateFx";
 import { ThumbCreateSchema } from "~/@buyer-user/thumb/schema/ThumbCreateSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NoticeSchema } from "~/schema/NoticeSchema";
@@ -89,40 +91,16 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/transaction-status/close.ts
+++ b/apps/server/src/@buyer-user/transaction-status/close.ts
@@ -1,10 +1,12 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { transactionStatusCloseFx } from "~/@buyer-user/transaction-status/fx/transactionStatusCloseFx";
 import { TransactionStatusCloseSchema } from "~/@buyer-user/transaction-status/schema/TransactionStatusCloseSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusSchema } from "~/@user/transaction-status/schema/TransactionStatusSchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -95,7 +97,7 @@ export const withCloseApiFx = Effect.fn("withCloseApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -103,50 +105,20 @@ export const withCloseApiFx = Effect.fn("withCloseApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "RuntimeError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								{ _tag: "RuntimeError" },
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/transaction-status/close.ts
+++ b/apps/server/src/@buyer-user/transaction-status/close.ts
@@ -45,14 +45,6 @@ export const withCloseApiFx = Effect.fn("withCloseApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -116,12 +108,12 @@ export const withCloseApiFx = Effect.fn("withCloseApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@buyer-user/transaction-status/close.ts
+++ b/apps/server/src/@buyer-user/transaction-status/close.ts
@@ -4,6 +4,7 @@ import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { transactionStatusCloseFx } from "~/@buyer-user/transaction-status/fx/transactionStatusCloseFx";
 import { TransactionStatusCloseSchema } from "~/@buyer-user/transaction-status/schema/TransactionStatusCloseSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusSchema } from "~/@user/transaction-status/schema/TransactionStatusSchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -94,13 +95,7 @@ export const withCloseApiFx = Effect.fn("withCloseApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -108,13 +103,7 @@ export const withCloseApiFx = Effect.fn("withCloseApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/transaction-status/dispute.ts
+++ b/apps/server/src/@buyer-user/transaction-status/dispute.ts
@@ -45,14 +45,6 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -116,12 +108,12 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@buyer-user/transaction-status/dispute.ts
+++ b/apps/server/src/@buyer-user/transaction-status/dispute.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -109,15 +109,21 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 								},
 							),
 							Match.when(
-								{ _tag: "InvalidRequestError" },
+								{
+									_tag: "InvalidRequestError",
+								},
 								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{ _tag: "RuntimeError" },
+								{
+									_tag: "RuntimeError",
+								},
 								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
-								{ _tag: "ZodErrorFx" },
+								{
+									_tag: "ZodErrorFx",
+								},
 								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,

--- a/apps/server/src/@buyer-user/transaction-status/dispute.ts
+++ b/apps/server/src/@buyer-user/transaction-status/dispute.ts
@@ -3,6 +3,8 @@ import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusDisputeSchema } from "~/@common/transaction-status/schema/TransactionStatusDisputeSchema";
 import { TransactionStatusSchema } from "~/@user/transaction-status/schema/TransactionStatusSchema";
@@ -95,7 +97,7 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -103,50 +105,20 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "RuntimeError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								{ _tag: "RuntimeError" },
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/transaction-status/dispute.ts
+++ b/apps/server/src/@buyer-user/transaction-status/dispute.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusDisputeSchema } from "~/@common/transaction-status/schema/TransactionStatusDisputeSchema";
 import { TransactionStatusSchema } from "~/@user/transaction-status/schema/TransactionStatusSchema";
@@ -94,13 +95,7 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -108,13 +103,7 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/transaction-status/reject.ts
+++ b/apps/server/src/@buyer-user/transaction-status/reject.ts
@@ -95,7 +95,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -103,7 +103,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/transaction-status/reject.ts
+++ b/apps/server/src/@buyer-user/transaction-status/reject.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusRejectSchema } from "~/@common/transaction-status/schema/TransactionStatusRejectSchema";
 import { TransactionStatusSchema } from "~/@user/transaction-status/schema/TransactionStatusSchema";
@@ -94,13 +95,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -108,13 +103,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/transaction-status/reject.ts
+++ b/apps/server/src/@buyer-user/transaction-status/reject.ts
@@ -45,14 +45,6 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -116,12 +108,12 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@buyer-user/transaction-status/reject.ts
+++ b/apps/server/src/@buyer-user/transaction-status/reject.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusRejectSchema } from "~/@common/transaction-status/schema/TransactionStatusRejectSchema";
 import { TransactionStatusSchema } from "~/@user/transaction-status/schema/TransactionStatusSchema";
@@ -94,59 +96,31 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "AccessDeniedError",
 								},
-								() => {
-									return c.json(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "RuntimeError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/transaction-status/success.ts
+++ b/apps/server/src/@buyer-user/transaction-status/success.ts
@@ -1,10 +1,12 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { transactionStatusSuccessFx } from "~/@buyer-user/transaction-status/fx/transactionStatusSuccessFx";
 import { TransactionStatusSuccessSchema } from "~/@buyer-user/transaction-status/schema/TransactionStatusSuccessSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusSchema } from "~/@user/transaction-status/schema/TransactionStatusSchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -92,62 +94,24 @@ export const withSuccessApiFx = Effect.fn("withSuccessApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "AccessDeniedError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "AccessDeniedError" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "RuntimeError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								{ _tag: "RuntimeError" },
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/transaction-status/success.ts
+++ b/apps/server/src/@buyer-user/transaction-status/success.ts
@@ -4,6 +4,7 @@ import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { transactionStatusSuccessFx } from "~/@buyer-user/transaction-status/fx/transactionStatusSuccessFx";
 import { TransactionStatusSuccessSchema } from "~/@buyer-user/transaction-status/schema/TransactionStatusSuccessSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusSchema } from "~/@user/transaction-status/schema/TransactionStatusSchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -95,13 +96,7 @@ export const withSuccessApiFx = Effect.fn("withSuccessApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -109,13 +104,7 @@ export const withSuccessApiFx = Effect.fn("withSuccessApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/transaction-status/success.ts
+++ b/apps/server/src/@buyer-user/transaction-status/success.ts
@@ -46,14 +46,6 @@ export const withSuccessApiFx = Effect.fn("withSuccessApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -117,12 +109,12 @@ export const withSuccessApiFx = Effect.fn("withSuccessApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@buyer-user/transaction/collection.ts
+++ b/apps/server/src/@buyer-user/transaction/collection.ts
@@ -1,8 +1,9 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { transactionCollectionFx } from "~/@buyer-user/transaction/fx/transactionCollectionFx";
 import { TransactionItemSchema } from "~/@buyer-user/transaction/schema/TransactionItemSchema";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
@@ -85,15 +86,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/transaction/create.ts
+++ b/apps/server/src/@buyer-user/transaction/create.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
@@ -6,6 +6,7 @@ import { transactionCreateFx } from "~/@buyer-user/transaction/fx/transactionCre
 import { TransactionCreateSchema } from "~/@buyer-user/transaction/schema/TransactionCreateSchema";
 import { TransactionSchema } from "~/@buyer-user/transaction/schema/TransactionSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
@@ -83,26 +84,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@buyer-user/transaction/create.ts
+++ b/apps/server/src/@buyer-user/transaction/create.ts
@@ -5,6 +5,7 @@ import { Effect, Match } from "effect";
 import { transactionCreateFx } from "~/@buyer-user/transaction/fx/transactionCreateFx";
 import { TransactionCreateSchema } from "~/@buyer-user/transaction/schema/TransactionCreateSchema";
 import { TransactionSchema } from "~/@buyer-user/transaction/schema/TransactionSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
@@ -86,13 +87,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@buyer-user/transaction/fetch.ts
+++ b/apps/server/src/@buyer-user/transaction/fetch.ts
@@ -4,6 +4,7 @@ import { Effect, Match } from "effect";
 import { transactionFetchFx } from "~/@buyer-user/transaction/fx/transactionFetchFx";
 import { TransactionSchema } from "~/@buyer-user/transaction/schema/TransactionSchema";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
@@ -85,7 +86,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -93,13 +94,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@buyer-user/transaction/fetch.ts
+++ b/apps/server/src/@buyer-user/transaction/fetch.ts
@@ -3,6 +3,7 @@ import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { transactionFetchFx } from "~/@buyer-user/transaction/fx/transactionFetchFx";
 import { TransactionSchema } from "~/@buyer-user/transaction/schema/TransactionSchema";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
@@ -84,13 +85,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@common/notice/NotFoundNotice.ts
+++ b/apps/server/src/@common/notice/NotFoundNotice.ts
@@ -1,0 +1,7 @@
+import type { NoticeSchema } from "~/schema/NoticeSchema";
+
+/** Standard 404 response body (not found / restricted / missing resource). Do not leak e.message. */
+export const NotFoundNotice: NoticeSchema.Type = {
+	type: "error",
+	message: "Nothing here",
+};

--- a/apps/server/src/@common/notice/noticeError.ts
+++ b/apps/server/src/@common/notice/noticeError.ts
@@ -1,0 +1,8 @@
+import type { NoticeSchema } from "~/schema/NoticeSchema";
+
+export const noticeError = (e: { message: string }): NoticeSchema.Type => {
+	return {
+		type: "error",
+		message: e.message,
+	};
+};

--- a/apps/server/src/@common/notice/noticeZodError.ts
+++ b/apps/server/src/@common/notice/noticeZodError.ts
@@ -1,0 +1,9 @@
+import { type ZodError, z } from "zod";
+import type { NoticeSchema } from "~/schema/NoticeSchema";
+
+export const noticeZodError = (zod: ZodError): NoticeSchema.Type => {
+	return {
+		type: "error",
+		message: z.prettifyError(zod),
+	};
+};

--- a/apps/server/src/@public/seed/seed.ts
+++ b/apps/server/src/@public/seed/seed.ts
@@ -5,6 +5,7 @@ import { TransactionContextProvider } from "~/@common/transaction/context/Transa
 import { SeedRequestSchema, seedFx } from "~/@public/seed/fx/seedFx";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { NoticeSchema } from "~/schema/NoticeSchema";
 
 export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
@@ -98,13 +99,7 @@ export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								(err) => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: err.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -112,13 +107,7 @@ export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								(err) => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: err.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@public/seed/seed.ts
+++ b/apps/server/src/@public/seed/seed.ts
@@ -6,6 +6,7 @@ import { SeedRequestSchema, seedFx } from "~/@public/seed/fx/seedFx";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
 import { NoticeSchema } from "~/schema/NoticeSchema";
 
 export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
@@ -81,48 +82,20 @@ export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								(err) => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: err.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								(err) => c.json(noticeError(err), 400),
 							),
 							Match.when(
-								{
-									_tag: "AccessDeniedError",
-								},
-								(err) => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "AccessDeniedError" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								(err) => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "RuntimeError",
-								},
-								(err) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: err.message,
-										},
-										500,
-									);
-								},
+								{ _tag: "RuntimeError" },
+								(err) => c.json(noticeError(err), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@public/seed/seed.ts
+++ b/apps/server/src/@public/seed/seed.ts
@@ -38,14 +38,6 @@ export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -106,12 +98,12 @@ export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								(err) => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: err.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@seller-session/transaction/buyer-info.ts
+++ b/apps/server/src/@seller-session/transaction/buyer-info.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { transactionGetBuyerInfoFx } from "~/@seller-session/transaction/fx/transactionGetBuyerInfoFx";
 import { TransactionBuyerInfoSchema } from "~/@seller-session/transaction/schema/TransactionBuyerInfoSchema";
@@ -92,7 +93,7 @@ export const withBuyerInfoApiFx = Effect.fn("withBuyerInfoApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -100,13 +101,7 @@ export const withBuyerInfoApiFx = Effect.fn("withBuyerInfoApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@seller-session/transaction/buyer-info.ts
+++ b/apps/server/src/@seller-session/transaction/buyer-info.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { transactionGetBuyerInfoFx } from "~/@seller-session/transaction/fx/transactionGetBuyerInfoFx";
 import { TransactionBuyerInfoSchema } from "~/@seller-session/transaction/schema/TransactionBuyerInfoSchema";
@@ -91,13 +92,7 @@ export const withBuyerInfoApiFx = Effect.fn("withBuyerInfoApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/draft-gallery/create.ts
+++ b/apps/server/src/@seller-user/draft-gallery/create.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { draftGalleryCreateFx } from "~/@seller-user/draft-gallery/fx/draftGalleryCreateFx";
 import { DraftGalleryCreateSchema } from "~/@seller-user/draft-gallery/schema/DraftGalleryCreateSchema";
 import { GallerySchema } from "~/@user/gallery/schema/GallerySchema";
@@ -89,48 +91,20 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "AccessDeniedError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "AccessDeniedError" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/draft-gallery/create.ts
+++ b/apps/server/src/@seller-user/draft-gallery/create.ts
@@ -44,14 +44,6 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -128,12 +120,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@seller-user/draft-gallery/create.ts
+++ b/apps/server/src/@seller-user/draft-gallery/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { draftGalleryCreateFx } from "~/@seller-user/draft-gallery/fx/draftGalleryCreateFx";
 import { DraftGalleryCreateSchema } from "~/@seller-user/draft-gallery/schema/DraftGalleryCreateSchema";
 import { GallerySchema } from "~/@user/gallery/schema/GallerySchema";
@@ -106,13 +107,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -120,13 +115,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/draft/collection.ts
+++ b/apps/server/src/@seller-user/draft/collection.ts
@@ -1,7 +1,8 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { draftCollectionFx } from "~/@seller-user/draft/fx/draftCollectionFx";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { DraftItemSchema } from "~/@seller-user/draft/schema/DraftItemSchema";
 import { DraftQuerySchema } from "~/@seller-user/draft/schema/DraftQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -83,18 +84,8 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/draft/count.ts
+++ b/apps/server/src/@seller-user/draft/count.ts
@@ -1,6 +1,7 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { draftCountFx } from "~/@seller-user/draft/fx/draftCountFx";
 import { DraftCountQuerySchema } from "~/@seller-user/draft/schema/DraftCountQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -75,15 +76,7 @@ export const withCountApiFx = Effect.fn("withCountApiFx")(function* () {
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/draft/create.ts
+++ b/apps/server/src/@seller-user/draft/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { draftCreateFx } from "~/@seller-user/draft/fx/draftCreateFx";
 import { DraftCreateSchema } from "~/@seller-user/draft/schema/DraftCreateSchema";
 import { DraftSchema } from "~/@seller-user/draft/schema/DraftSchema";
@@ -93,13 +94,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/draft/create.ts
+++ b/apps/server/src/@seller-user/draft/create.ts
@@ -1,8 +1,9 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { draftCreateFx } from "~/@seller-user/draft/fx/draftCreateFx";
 import { DraftCreateSchema } from "~/@seller-user/draft/schema/DraftCreateSchema";
 import { DraftSchema } from "~/@seller-user/draft/schema/DraftSchema";
@@ -90,26 +91,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/draft/delete.ts
+++ b/apps/server/src/@seller-user/draft/delete.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { draftDeleteFx } from "~/@seller-user/draft/fx/draftDeleteFx";
 import { DraftQuerySchema } from "~/@seller-user/draft/schema/DraftQuerySchema";
 import { DraftSchema } from "~/@seller-user/draft/schema/DraftSchema";
@@ -85,13 +86,7 @@ export const withDeleteApiFx = Effect.fn("withDeleteApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/draft/delete.ts
+++ b/apps/server/src/@seller-user/draft/delete.ts
@@ -1,7 +1,8 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { draftDeleteFx } from "~/@seller-user/draft/fx/draftDeleteFx";
 import { DraftQuerySchema } from "~/@seller-user/draft/schema/DraftQuerySchema";
 import { DraftSchema } from "~/@seller-user/draft/schema/DraftSchema";
@@ -86,7 +87,7 @@ export const withDeleteApiFx = Effect.fn("withDeleteApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -94,13 +95,7 @@ export const withDeleteApiFx = Effect.fn("withDeleteApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@seller-user/draft/fetch.ts
+++ b/apps/server/src/@seller-user/draft/fetch.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { draftFetchFx } from "~/@seller-user/draft/fx/draftFetchFx";
 import { DraftQuerySchema } from "~/@seller-user/draft/schema/DraftQuerySchema";
 import { DraftSchema } from "~/@seller-user/draft/schema/DraftSchema";
@@ -85,13 +86,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/draft/fetch.ts
+++ b/apps/server/src/@seller-user/draft/fetch.ts
@@ -1,7 +1,8 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { draftFetchFx } from "~/@seller-user/draft/fx/draftFetchFx";
 import { DraftQuerySchema } from "~/@seller-user/draft/schema/DraftQuerySchema";
 import { DraftSchema } from "~/@seller-user/draft/schema/DraftSchema";
@@ -86,7 +87,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -94,13 +95,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@seller-user/draft/patch.ts
+++ b/apps/server/src/@seller-user/draft/patch.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { draftPatchFx } from "~/@seller-user/draft/fx/draftPatchFx";
 import { DraftPatchSchema } from "~/@seller-user/draft/schema/DraftPatchSchema";
 import { DraftSchema } from "~/@seller-user/draft/schema/DraftSchema";
@@ -95,13 +96,7 @@ export const withPatchApiFx = Effect.fn("withPatchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/draft/patch.ts
+++ b/apps/server/src/@seller-user/draft/patch.ts
@@ -1,8 +1,9 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { draftPatchFx } from "~/@seller-user/draft/fx/draftPatchFx";
 import { DraftPatchSchema } from "~/@seller-user/draft/schema/DraftPatchSchema";
 import { DraftSchema } from "~/@seller-user/draft/schema/DraftSchema";
@@ -96,7 +97,7 @@ export const withPatchApiFx = Effect.fn("withPatchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -104,13 +105,7 @@ export const withPatchApiFx = Effect.fn("withPatchApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@seller-user/listing/collection.ts
+++ b/apps/server/src/@seller-user/listing/collection.ts
@@ -1,6 +1,7 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { listingCollectionFx } from "~/@seller-user/listing/fx/listingCollectionFx";
 import { ListingItemSchema } from "~/@seller-user/listing/schema/ListingItemSchema";
 import { ListingQuerySchema } from "~/@seller-user/listing/schema/ListingQuerySchema";
@@ -84,15 +85,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/listing/count.ts
+++ b/apps/server/src/@seller-user/listing/count.ts
@@ -1,6 +1,7 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { listingCountFx } from "~/@seller-user/listing/fx/listingCountFx";
 import { ListingCountQuerySchema } from "~/@seller-user/listing/schema/ListingCountQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -73,15 +74,7 @@ export const withCountApiFx = Effect.fn("withCountApiFx")(function* () {
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/listing/create.ts
+++ b/apps/server/src/@seller-user/listing/create.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { listingCreateFx } from "~/@seller-user/listing/fx/listingCreateFx";
 import { ListingCreateSchema } from "~/@seller-user/listing/schema/ListingCreateSchema";
 import { ListingSchema } from "~/@seller-user/listing/schema/ListingSchema";
@@ -89,40 +91,16 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/listing/create.ts
+++ b/apps/server/src/@seller-user/listing/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { listingCreateFx } from "~/@seller-user/listing/fx/listingCreateFx";
 import { ListingCreateSchema } from "~/@seller-user/listing/schema/ListingCreateSchema";
 import { ListingSchema } from "~/@seller-user/listing/schema/ListingSchema";
@@ -92,13 +93,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/listing/fetch.ts
+++ b/apps/server/src/@seller-user/listing/fetch.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { listingFetchFx } from "~/@seller-user/listing/fx/listingFetchFx";
 import { ListingQuerySchema } from "~/@seller-user/listing/schema/ListingQuerySchema";
 import { ListingSchema } from "~/@seller-user/listing/schema/ListingSchema";
@@ -84,7 +85,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -92,13 +93,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@seller-user/listing/fetch.ts
+++ b/apps/server/src/@seller-user/listing/fetch.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { listingFetchFx } from "~/@seller-user/listing/fx/listingFetchFx";
 import { ListingQuerySchema } from "~/@seller-user/listing/schema/ListingQuerySchema";
 import { ListingSchema } from "~/@seller-user/listing/schema/ListingSchema";
@@ -83,13 +84,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/transaction-listing/collection.ts
+++ b/apps/server/src/@seller-user/transaction-listing/collection.ts
@@ -1,7 +1,8 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { transactionListingCollectionFx } from "~/@seller-user/transaction-listing/fx/transactionListingCollectionFx";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionListingItemSchema } from "~/@seller-user/transaction-listing/schema/TransactionListingItemSchema";
 import { TransactionListingQuerySchema } from "~/@seller-user/transaction-listing/schema/TransactionListingQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -85,18 +86,8 @@ export const withCollectionApiFx = Effect.fn("withTransactionListingCollectionAp
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/transaction-status/accept.ts
+++ b/apps/server/src/@seller-user/transaction-status/accept.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { transactionStatusAcceptFx } from "~/@seller-user/transaction-status/fx/transactionStatusAcceptFx";
 import { TransactionStatusAcceptSchema } from "~/@seller-user/transaction-status/schema/TransactionStatusAcceptSchema";
@@ -86,13 +87,7 @@ export const withAcceptApiFx = Effect.fn("withAcceptApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -100,13 +95,7 @@ export const withAcceptApiFx = Effect.fn("withAcceptApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/transaction-status/accept.ts
+++ b/apps/server/src/@seller-user/transaction-status/accept.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { transactionStatusAcceptFx } from "~/@seller-user/transaction-status/fx/transactionStatusAcceptFx";
 import { TransactionStatusAcceptSchema } from "~/@seller-user/transaction-status/schema/TransactionStatusAcceptSchema";
@@ -86,45 +88,25 @@ export const withAcceptApiFx = Effect.fn("withAcceptApiFx")(function* () {
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "AccessDeniedError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "RuntimeError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/transaction-status/accept.ts
+++ b/apps/server/src/@seller-user/transaction-status/accept.ts
@@ -37,14 +37,6 @@ export const withAcceptApiFx = Effect.fn("withAcceptApiFx")(function* () {
 					},
 					description: "Accepted status created",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -108,12 +100,12 @@ export const withAcceptApiFx = Effect.fn("withAcceptApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@seller-user/transaction-status/dispute.ts
+++ b/apps/server/src/@seller-user/transaction-status/dispute.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusDisputeSchema } from "~/@common/transaction-status/schema/TransactionStatusDisputeSchema";
 import { TransactionStatusSchema } from "~/@seller-user/transaction-status/schema/TransactionStatusSchema";
@@ -94,13 +95,7 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -108,13 +103,7 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/transaction-status/dispute.ts
+++ b/apps/server/src/@seller-user/transaction-status/dispute.ts
@@ -45,14 +45,6 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -116,12 +108,12 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@seller-user/transaction-status/dispute.ts
+++ b/apps/server/src/@seller-user/transaction-status/dispute.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusDisputeSchema } from "~/@common/transaction-status/schema/TransactionStatusDisputeSchema";
 import { TransactionStatusSchema } from "~/@seller-user/transaction-status/schema/TransactionStatusSchema";
@@ -94,59 +96,31 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "AccessDeniedError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "RuntimeError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/transaction-status/reject.ts
+++ b/apps/server/src/@seller-user/transaction-status/reject.ts
@@ -96,41 +96,31 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "AccessDeniedError",
 								},
-								() => {
-									return c.json(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json(noticeError(e), 400);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "RuntimeError",
 								},
-								() => {
-									return c.json(noticeError(e), 500);
-								},
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json(noticeZodError(zod), 500);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/transaction-status/reject.ts
+++ b/apps/server/src/@seller-user/transaction-status/reject.ts
@@ -45,14 +45,6 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -116,12 +108,12 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@seller-user/transaction-status/reject.ts
+++ b/apps/server/src/@seller-user/transaction-status/reject.ts
@@ -1,7 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { TransactionStatusRejectSchema } from "~/@common/transaction-status/schema/TransactionStatusRejectSchema";
 import { TransactionStatusSchema } from "~/@seller-user/transaction-status/schema/TransactionStatusSchema";
@@ -94,13 +97,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -108,13 +105,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -122,13 +113,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "InvalidRequestError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
+									return c.json(noticeError(e), 400);
 								},
 							),
 							Match.when(
@@ -136,13 +121,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "RuntimeError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
+									return c.json(noticeError(e), 500);
 								},
 							),
 							Match.when(
@@ -150,13 +129,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@seller-user/transaction-status/resolve.ts
+++ b/apps/server/src/@seller-user/transaction-status/resolve.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { transactionStatusResolveFx } from "~/@seller-user/transaction-status/fx/transactionStatusResolveFx";
 import { TransactionStatusResolveSchema } from "~/@seller-user/transaction-status/schema/TransactionStatusResolveSchema";
@@ -94,13 +95,7 @@ export const withResolveApiFx = Effect.fn("withResolveApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -122,13 +117,7 @@ export const withResolveApiFx = Effect.fn("withResolveApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@seller-user/transaction-status/resolve.ts
+++ b/apps/server/src/@seller-user/transaction-status/resolve.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { transactionStatusResolveFx } from "~/@seller-user/transaction-status/fx/transactionStatusResolveFx";
 import { TransactionStatusResolveSchema } from "~/@seller-user/transaction-status/schema/TransactionStatusResolveSchema";
@@ -94,59 +96,31 @@ export const withResolveApiFx = Effect.fn("withResolveApiFx")(function* () {
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "AccessDeniedError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "RuntimeError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/transaction-status/resolve.ts
+++ b/apps/server/src/@seller-user/transaction-status/resolve.ts
@@ -45,14 +45,6 @@ export const withResolveApiFx = Effect.fn("withResolveApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -130,12 +122,12 @@ export const withResolveApiFx = Effect.fn("withResolveApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@seller-user/transaction/collection.ts
+++ b/apps/server/src/@seller-user/transaction/collection.ts
@@ -1,6 +1,7 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { transactionCollectionFx } from "~/@seller-user/transaction/fx/transactionCollectionFx";
 import { TransactionItemSchema } from "~/@seller-user/transaction/schema/TransactionItemSchema";
@@ -85,15 +86,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@seller-user/transaction/fetch.ts
+++ b/apps/server/src/@seller-user/transaction/fetch.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { transactionFetchFx } from "~/@seller-user/transaction/fx/transactionFetchFx";
 import { TransactionSchema } from "~/@seller-user/transaction/schema/TransactionSchema";
@@ -85,7 +86,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -93,13 +94,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@seller-user/transaction/fetch.ts
+++ b/apps/server/src/@seller-user/transaction/fetch.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { transactionFetchFx } from "~/@seller-user/transaction/fx/transactionFetchFx";
 import { TransactionSchema } from "~/@seller-user/transaction/schema/TransactionSchema";
@@ -84,13 +85,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@session/category/collection.ts
+++ b/apps/server/src/@session/category/collection.ts
@@ -1,7 +1,8 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { categoryCollectionFx } from "~/@session/category/fx/categoryCollectionFx";
 import { CategoryItemSchema } from "~/@session/category/schema/CategoryItemSchema";
 import { CategoryQuerySchema } from "~/@session/category/schema/CategoryQuerySchema";
@@ -84,15 +85,7 @@ export const withCategoryCollectionApiFx = Effect.fn("withCategoryCollectionApiF
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@session/category/count.ts
+++ b/apps/server/src/@session/category/count.ts
@@ -1,7 +1,8 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { categoryCountFx } from "~/@session/category/fx/categoryCountFx";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { CategoryCountQuerySchema } from "~/@session/category/schema/CategoryCountQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
 import { RoutesContextFx } from "~/route/context/RoutesContextFx";
@@ -68,18 +69,8 @@ export const withCategoryCountApiFx = Effect.fn("withCategoryCountApiFx")(functi
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@session/category/fetch.ts
+++ b/apps/server/src/@session/category/fetch.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { categoryFetchFx } from "~/@session/category/fx/categoryFetchFx";
 import { CategoryQuerySchema } from "~/@session/category/schema/CategoryQuerySchema";
 import { CategorySchema } from "~/@session/category/schema/CategorySchema";
@@ -81,23 +82,11 @@ export const withCategoryFetchApiFx = Effect.fn("withCategoryFetchApiFx")(functi
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@session/category/fetch.ts
+++ b/apps/server/src/@session/category/fetch.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { categoryFetchFx } from "~/@session/category/fx/categoryFetchFx";
 import { CategoryQuerySchema } from "~/@session/category/schema/CategoryQuerySchema";
 import { CategorySchema } from "~/@session/category/schema/CategorySchema";
@@ -81,13 +82,7 @@ export const withCategoryFetchApiFx = Effect.fn("withCategoryFetchApiFx")(functi
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@session/location/autocomplete.ts
+++ b/apps/server/src/@session/location/autocomplete.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { LocationContextLayer } from "~/@session/location/context/LocationContextLayer";
 import { locationAutocompleteFx } from "~/@session/location/fx/locationAutocompleteFx";
 import { LocationAutocompleteSchema } from "~/@session/location/schema/LocationAutocompleteSchema";
@@ -97,15 +98,7 @@ export const withLocationAutocompleteApiFx = Effect.fn("withLocationAutocomplete
 									{
 										_tag: "ZodErrorFx",
 									},
-									({ zod }) => {
-										return c.json<NoticeSchema.Type, 500>(
-											{
-												type: "error",
-												message: z.prettifyError(zod),
-											},
-											500,
-										);
-									},
+									({ zod }) => c.json(noticeZodError(zod), 500),
 								),
 								Match.exhaustive,
 							),

--- a/apps/server/src/@session/location/fetch.ts
+++ b/apps/server/src/@session/location/fetch.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { locationFetchFx } from "~/@session/location/fx/locationFetchFx";
 import { LocationQuerySchema } from "~/@session/location/schema/LocationQuerySchema";
 import { LocationSchema } from "~/@session/location/schema/LocationSchema";
@@ -80,13 +81,7 @@ export const withLocationFetchApiFx = Effect.fn("withLocationFetchApiFx")(functi
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@session/location/fetch.ts
+++ b/apps/server/src/@session/location/fetch.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { locationFetchFx } from "~/@session/location/fx/locationFetchFx";
 import { LocationQuerySchema } from "~/@session/location/schema/LocationQuerySchema";
 import { LocationSchema } from "~/@session/location/schema/LocationSchema";
@@ -81,7 +82,7 @@ export const withLocationFetchApiFx = Effect.fn("withLocationFetchApiFx")(functi
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -89,13 +90,7 @@ export const withLocationFetchApiFx = Effect.fn("withLocationFetchApiFx")(functi
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@user/gallery/collection.ts
+++ b/apps/server/src/@user/gallery/collection.ts
@@ -1,6 +1,7 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { galleryCollectionFx } from "~/@user/gallery/fx/galleryCollectionFx";
 import { GalleryItemSchema } from "~/@user/gallery/schema/GalleryItemSchema";
 import { GalleryQuerySchema } from "~/@user/gallery/schema/GalleryQuerySchema";
@@ -85,15 +86,7 @@ export const withCollectionApiFx = Effect.fn("withCollectionApiFx")(function* ()
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/gallery/count.ts
+++ b/apps/server/src/@user/gallery/count.ts
@@ -1,6 +1,7 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { galleryCountFx } from "~/@user/gallery/fx/galleryCountFx";
 import { GalleryCountQuerySchema } from "~/@user/gallery/schema/GalleryCountQuerySchema";
 import { KyselyContextLayer } from "~/database/context/KyselyContextLayer";
@@ -71,18 +72,8 @@ export const withCountApiFx = Effect.fn("withCountApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/gallery/fetch.ts
+++ b/apps/server/src/@user/gallery/fetch.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { galleryFetchFx } from "~/@user/gallery/fx/galleryFetchFx";
 import { GalleryQuerySchema } from "~/@user/gallery/schema/GalleryQuerySchema";
 import { GallerySchema } from "~/@user/gallery/schema/GallerySchema";
@@ -84,13 +85,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/gallery/fetch.ts
+++ b/apps/server/src/@user/gallery/fetch.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { galleryFetchFx } from "~/@user/gallery/fx/galleryFetchFx";
 import { GalleryQuerySchema } from "~/@user/gallery/schema/GalleryQuerySchema";
 import { GallerySchema } from "~/@user/gallery/schema/GallerySchema";
@@ -85,7 +86,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -93,13 +94,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@user/message-thread/message/collection.ts
+++ b/apps/server/src/@user/message-thread/message/collection.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { messageCollectionFx } from "~/@user/message/fx/messageCollectionFx";
 import { MessageQuerySchema } from "~/@user/message/schema/MessageQuerySchema";
 import { MessageItemSchema } from "~/@user/message-thread/message/schema/MessageItemSchema";
@@ -117,13 +118,7 @@ export const withMessageCollectionApiFx = Effect.fn("withMessageCollectionApiFx"
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/message-thread/message/collection.ts
+++ b/apps/server/src/@user/message-thread/message/collection.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { messageCollectionFx } from "~/@user/message/fx/messageCollectionFx";
 import { MessageQuerySchema } from "~/@user/message/schema/MessageQuerySchema";
 import { MessageItemSchema } from "~/@user/message-thread/message/schema/MessageItemSchema";
@@ -118,7 +119,7 @@ export const withMessageCollectionApiFx = Effect.fn("withMessageCollectionApiFx"
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
+									return c.json(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -126,13 +127,7 @@ export const withMessageCollectionApiFx = Effect.fn("withMessageCollectionApiFx"
 									_tag: "ZodErrorFx",
 								},
 								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
+									return c.json(noticeZodError(zod), 500);
 								},
 							),
 							Match.exhaustive,

--- a/apps/server/src/@user/s3/presign.ts
+++ b/apps/server/src/@user/s3/presign.ts
@@ -1,7 +1,8 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { S3ContextLayer } from "~/@common/s3/context/S3ContextLayer";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { s3PreSignFx } from "~/@common/s3/fx/s3PreSignFx";
 import { UploadContextLayer } from "~/@common/upload/context/UploadContextLayer";
 import { S3PreSignRequestSchema } from "~/@user/s3/schema/S3PreSignRequestSchema";
@@ -91,18 +92,8 @@ export const withPresignApiFx = Effect.fn("withPresignApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/transaction-message-gallery/create.ts
+++ b/apps/server/src/@user/transaction-message-gallery/create.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessageGallerySchema } from "~/@user/message-gallery/schema/MessageGallerySchema";
 import { transactionMessageGalleryCreateFx } from "~/@user/transaction-message-gallery/fx/transactionMessageGalleryCreateFx";
@@ -95,59 +97,31 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "AccessDeniedError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "RuntimeError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/transaction-message-gallery/create.ts
+++ b/apps/server/src/@user/transaction-message-gallery/create.ts
@@ -46,14 +46,6 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -131,12 +123,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@user/transaction-message-gallery/create.ts
+++ b/apps/server/src/@user/transaction-message-gallery/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessageGallerySchema } from "~/@user/message-gallery/schema/MessageGallerySchema";
 import { transactionMessageGalleryCreateFx } from "~/@user/transaction-message-gallery/fx/transactionMessageGalleryCreateFx";
@@ -109,13 +110,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -123,13 +118,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/transaction-message-location/create.ts
+++ b/apps/server/src/@user/transaction-message-location/create.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessageLocationSchema } from "~/@user/message-location/schema/MessageLocationSchema";
 import { transactionMessageLocationCreateFx } from "~/@user/transaction-message-location/fx/transactionMessageLocationCreateFx";
@@ -95,59 +97,31 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 								{
 									_tag: "InvalidRequestError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "AccessDeniedError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "RuntimeError",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/transaction-message-location/create.ts
+++ b/apps/server/src/@user/transaction-message-location/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessageLocationSchema } from "~/@user/message-location/schema/MessageLocationSchema";
 import { transactionMessageLocationCreateFx } from "~/@user/transaction-message-location/fx/transactionMessageLocationCreateFx";
@@ -109,13 +110,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -123,13 +118,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/transaction-message-location/create.ts
+++ b/apps/server/src/@user/transaction-message-location/create.ts
@@ -46,14 +46,6 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -131,12 +123,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@user/transaction-message-package/create.ts
+++ b/apps/server/src/@user/transaction-message-package/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessagePackageSchema } from "~/@user/message-package/schema/MessagePackageSchema";
 import { transactionMessagePackageCreateFx } from "~/@user/transaction-message-package/fx/transactionMessagePackageCreateFx";
@@ -109,13 +110,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -123,13 +118,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/transaction-message-package/create.ts
+++ b/apps/server/src/@user/transaction-message-package/create.ts
@@ -46,14 +46,6 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -131,12 +123,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@user/transaction-message-package/create.ts
+++ b/apps/server/src/@user/transaction-message-package/create.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessagePackageSchema } from "~/@user/message-package/schema/MessagePackageSchema";
 import { transactionMessagePackageCreateFx } from "~/@user/transaction-message-package/fx/transactionMessagePackageCreateFx";
@@ -92,62 +94,24 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "AccessDeniedError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "AccessDeniedError" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "RuntimeError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								{ _tag: "RuntimeError" },
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/transaction-message-personal/create.ts
+++ b/apps/server/src/@user/transaction-message-personal/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessagePersonalSchema } from "~/@user/message-personal/schema/MessagePersonalSchema";
 import { transactionMessagePersonalCreateFx } from "~/@user/transaction-message-personal/fx/transactionMessagePersonalCreateFx";
@@ -96,13 +97,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -138,13 +133,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/transaction-message-personal/create.ts
+++ b/apps/server/src/@user/transaction-message-personal/create.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessagePersonalSchema } from "~/@user/message-personal/schema/MessagePersonalSchema";
 import { transactionMessagePersonalCreateFx } from "~/@user/transaction-message-personal/fx/transactionMessagePersonalCreateFx";
@@ -93,62 +95,24 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "RuntimeError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								{ _tag: "RuntimeError" },
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "AccessDeniedError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "AccessDeniedError" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/transaction-message-personal/create.ts
+++ b/apps/server/src/@user/transaction-message-personal/create.ts
@@ -47,14 +47,6 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -146,12 +138,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@user/transaction-message-text/create.ts
+++ b/apps/server/src/@user/transaction-message-text/create.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessageTextSchema } from "~/@user/message-text/schema/MessageTextSchema";
 import { transactionMessageTextCreateFx } from "~/@user/transaction-message-text/fx/transactionMessageTextCreateFx";
@@ -92,62 +94,24 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "AccessDeniedError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "AccessDeniedError" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "RuntimeError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										500,
-									);
-								},
+								{ _tag: "RuntimeError" },
+								() => c.json(noticeError(e), 500),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/transaction-message-text/create.ts
+++ b/apps/server/src/@user/transaction-message-text/create.ts
@@ -46,14 +46,6 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					},
 					description: "Invalid request",
 				},
-				403: {
-					content: {
-						"application/json": {
-							schema: NoticeSchema,
-						},
-					},
-					description: "Access denied",
-				},
 				404: {
 					content: {
 						"application/json": {
@@ -131,12 +123,12 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 403>(
+									return c.json<NoticeSchema.Type, 404>(
 										{
 											type: "error",
 											message: e.message,
 										},
-										403,
+										404,
 									);
 								},
 							),

--- a/apps/server/src/@user/transaction-message-text/create.ts
+++ b/apps/server/src/@user/transaction-message-text/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { TransactionContextProvider } from "~/@common/transaction/context/TransactionContextFx";
 import { MessageTextSchema } from "~/@user/message-text/schema/MessageTextSchema";
 import { transactionMessageTextCreateFx } from "~/@user/transaction-message-text/fx/transactionMessageTextCreateFx";
@@ -109,13 +110,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(
@@ -123,13 +118,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "AccessDeniedError",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/upload/create.ts
+++ b/apps/server/src/@user/upload/create.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { UploadContextLayer } from "~/@common/upload/context/UploadContextLayer";
 import { uploadCreateFx } from "~/@user/upload/fx/uploadCreateFx";
 import { UploadCreateSchema } from "~/@user/upload/schema/UploadCreateSchema";
@@ -115,13 +116,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/upload/create.ts
+++ b/apps/server/src/@user/upload/create.ts
@@ -1,8 +1,10 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { createDateContext, DateContextLayer } from "@use-pico/common/date";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { UploadContextLayer } from "~/@common/upload/context/UploadContextLayer";
 import { uploadCreateFx } from "~/@user/upload/fx/uploadCreateFx";
 import { UploadCreateSchema } from "~/@user/upload/schema/UploadCreateSchema";
@@ -98,40 +100,16 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					return Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "InvalidRequestError",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 400>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										400,
-									);
-								},
+								{ _tag: "InvalidRequestError" },
+								() => c.json(noticeError(e), 400),
 							),
 							Match.when(
-								{
-									_tag: "NotFoundErrorFx",
-								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								{ _tag: "NotFoundErrorFx" },
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/upload/fetch.ts
+++ b/apps/server/src/@user/upload/fetch.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { uploadFetchFx } from "~/@user/upload/fx/uploadFetchFx";
 import { UploadQuerySchema } from "~/@user/upload/schema/UploadQuerySchema";
 import { UploadSchema } from "~/@user/upload/schema/UploadSchema";
@@ -80,23 +81,13 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 								{
 									_tag: "NotFoundErrorFx",
 								},
-								() => {
-									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
-								},
+								() => c.json(NotFoundNotice, 404),
 							),
 							Match.when(
 								{
 									_tag: "ZodErrorFx",
 								},
-								({ zod }) => {
-									return c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									);
-								},
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/apps/server/src/@user/upload/fetch.ts
+++ b/apps/server/src/@user/upload/fetch.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
 import { uploadFetchFx } from "~/@user/upload/fx/uploadFetchFx";
 import { UploadQuerySchema } from "~/@user/upload/schema/UploadQuerySchema";
 import { UploadSchema } from "~/@user/upload/schema/UploadSchema";
@@ -80,13 +81,7 @@ export const withFetchApiFx = Effect.fn("withFetchApiFx")(function* () {
 									_tag: "NotFoundErrorFx",
 								},
 								() => {
-									return c.json<NoticeSchema.Type, 404>(
-										{
-											type: "error",
-											message: e.message,
-										},
-										404,
-									);
+									return c.json<NoticeSchema.Type, 404>(NotFoundNotice, 404);
 								},
 							),
 							Match.when(

--- a/apps/server/src/@user/user-ex/patch.ts
+++ b/apps/server/src/@user/user-ex/patch.ts
@@ -1,6 +1,7 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { zodFx } from "@use-pico/common/schema";
 import { Effect, Match } from "effect";
+import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { userExPatchFx } from "~/@user/user-ex/fx/userExPatchFx";
 import { UserExPatchSchema } from "~/@user/user-ex/schema/UserExPatchSchema";
 import { UserExSchema } from "~/@user/user-ex/schema/UserExSchema";
@@ -71,17 +72,8 @@ export const withPatchApiFx = Effect.fn("withPatchApiFx")(function* () {
 					Effect.succeed(
 						Match.value(e).pipe(
 							Match.when(
-								{
-									_tag: "ZodErrorFx",
-								},
-								({ zod }) =>
-									c.json<NoticeSchema.Type, 500>(
-										{
-											type: "error",
-											message: z.prettifyError(zod),
-										},
-										500,
-									),
+								{ _tag: "ZodErrorFx" },
+								({ zod }) => c.json(noticeZodError(zod), 500),
 							),
 							Match.exhaustive,
 						),

--- a/packages/@zbav-se.me/sdk/src/api/buyer-user/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/buyer-user/types.gen.ts
@@ -1945,10 +1945,6 @@ export type apiFeedGalleryCreateErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Feed not found or not accessible
      */
     404: tNotice;
@@ -2358,10 +2354,6 @@ export type apiTransactionStatusCloseErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Listing transaction not found or not accessible
      */
     404: tNotice;
@@ -2397,10 +2389,6 @@ export type apiTransactionStatusDisputeErrors = {
      * Invalid request
      */
     400: tNotice;
-    /**
-     * Access denied
-     */
-    403: tNotice;
     /**
      * Listing transaction not found or not accessible
      */
@@ -2438,10 +2426,6 @@ export type apiTransactionStatusRejectErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Listing transaction not found or not accessible
      */
     404: tNotice;
@@ -2477,10 +2461,6 @@ export type apiTransactionStatusSuccessErrors = {
      * Invalid request
      */
     400: tNotice;
-    /**
-     * Access denied
-     */
-    403: tNotice;
     /**
      * Listing transaction not found or not accessible
      */

--- a/packages/@zbav-se.me/sdk/src/api/public/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/public/types.gen.ts
@@ -1155,10 +1155,6 @@ export type apiSeedErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * User not found
      */
     404: tNotice;

--- a/packages/@zbav-se.me/sdk/src/api/seller-user/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/seller-user/types.gen.ts
@@ -1494,10 +1494,6 @@ export type apiDraftGalleryCreateErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Draft not found or not accessible
      */
     404: tNotice;
@@ -1730,10 +1726,6 @@ export type tApiTransactionStatusAcceptRequest = {
 
 export type apiTransactionStatusAcceptErrors = {
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Listing transaction not found or not accessible
      */
     404: tNotice;
@@ -1769,10 +1761,6 @@ export type apiTransactionStatusDisputeErrors = {
      * Invalid request
      */
     400: tNotice;
-    /**
-     * Access denied
-     */
-    403: tNotice;
     /**
      * Listing transaction not found or not accessible
      */
@@ -1810,10 +1798,6 @@ export type apiTransactionStatusRejectErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Listing transaction not found or not accessible
      */
     404: tNotice;
@@ -1849,10 +1833,6 @@ export type apiTransactionStatusResolveErrors = {
      * Invalid request
      */
     400: tNotice;
-    /**
-     * Access denied
-     */
-    403: tNotice;
     /**
      * Listing transaction not found or not accessible
      */

--- a/packages/@zbav-se.me/sdk/src/api/user/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/user/types.gen.ts
@@ -979,10 +979,6 @@ export type apiTransactionMessageGalleryCreateErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Transaction not found or not accessible
      */
     404: tNotice;
@@ -1018,10 +1014,6 @@ export type apiTransactionMessageLocationCreateErrors = {
      * Invalid request
      */
     400: tNotice;
-    /**
-     * Access denied
-     */
-    403: tNotice;
     /**
      * Transaction not found or not accessible
      */
@@ -1059,10 +1051,6 @@ export type apiTransactionMessagePackageCreateErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Transaction not found or not accessible
      */
     404: tNotice;
@@ -1099,10 +1087,6 @@ export type apiTransactionMessagePersonalCreateErrors = {
      */
     400: tNotice;
     /**
-     * Access denied
-     */
-    403: tNotice;
-    /**
      * Transaction not found or not accessible
      */
     404: tNotice;
@@ -1138,10 +1122,6 @@ export type apiTransactionMessageTextCreateErrors = {
      * Invalid request
      */
     400: tNotice;
-    /**
-     * Access denied
-     */
-    403: tNotice;
     /**
      * Transaction not found or not accessible
      */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly a mechanical refactor, but it changes externally observable HTTP status codes (notably `403` to `404`) and error messages for multiple endpoints, which could break clients/tests that depend on prior behavior.
> 
> **Overview**
> **Unifies API error handling across many server routes** by introducing shared helpers `noticeError`, `noticeZodError`, and a standard `NotFoundNotice`, then replacing repeated inline JSON error bodies with these helpers.
> 
> **Changes semantics for authorization failures:** several endpoints now return `404` with `NotFoundNotice` for `AccessDeniedError` (and stop advertising `403` in OpenAPI), aligning “not accessible” with “not found” to reduce information leakage; generated SDK error types are updated accordingly. A tiny formatting-only change was also made in the app’s dev seed route (`generateProsCons`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b13bc0f8dbb4b82cb26e4dfb86764bbbe5389b85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->