### PR TITLE
Dev: Resolve logging external service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ translation/           # i18n files (cs.yaml, en.yaml)
 2. **Respect domain boundaries**: Don't mix buyer/seller logic. Use appropriate API context.
 3. **Follow Effect patterns**: Use Context.Tag for dependencies, Effect.fn for composition. Use `Effect.annotateLogsScoped` in handlers so logs are tagged with endpoint and context.
 4. **Type safety**: Use Kysely for DB, Zod for schemas, generated SDK types.
-5. **Error handling**: Use custom error types (AccessDeniedError, InvalidRequestError, etc.).
+5. **Error handling**: Use custom error types (AccessDeniedErrorFx, InvalidRequestErrorFx, etc.).
 6. **Respect limits**: Check subscription tiers, pass states, listing limits before operations.
 7. **Transaction lifecycle**: Understand states and terminal conditions.
 8. **Sensitivity gates**: Always check user's maximum sensitivity before showing content.

--- a/apps/server/src/@buyer-session/listing-event/create.ts
+++ b/apps/server/src/@buyer-session/listing-event/create.ts
@@ -106,13 +106,13 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				withKyselyFx(c.get("kysely")),
 				withDateFx,
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					TooManyRequests(e) {
+					TooManyRequestsFx(e) {
 						return c.json(noticeError(e), 429);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@buyer-session/listing-event/fx/listingEventCollectionFx.ts
+++ b/apps/server/src/@buyer-session/listing-event/fx/listingEventCollectionFx.ts
@@ -1,5 +1,6 @@
 import { withCollectionFx } from "@use-pico/common/collection";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withListingEventCollectionSelectFx } from "~/@buyer-session/listing-event/db/withListingEventCollectionSelectFx";
 import { withListingEventQueryBuilderFx } from "~/@buyer-session/listing-event/db/withListingEventQueryBuilderFx";
 import type { ListingEventFilterSchema } from "~/@buyer-session/listing-event/schema/ListingEventFilterSchema";
@@ -18,12 +19,9 @@ export const listingEventCollectionFx = Effect.fn("listingEventCollectionFx")(fu
 	sort,
 	scope,
 }: listingEventCollectionFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingEventCollectionFx.cursor": cursor,
-		"listingEventCollectionFx.filter": filter,
-		"listingEventCollectionFx.where": where,
-		"listingEventCollectionFx.sort": sort,
-		"listingEventCollectionFx.scope": scope,
+	yield* withTraceFx({
+		fx: "listingEventCollectionFx",
+		input: { cursor, filter, where, sort, scope },
 	});
 
 	return yield* withCollectionFx({

--- a/apps/server/src/@buyer-session/listing-event/fx/listingEventCountFx.ts
+++ b/apps/server/src/@buyer-session/listing-event/fx/listingEventCountFx.ts
@@ -1,5 +1,6 @@
 import { withCountFx } from "@use-pico/common/count";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withListingEventCollectionSelectFx } from "~/@buyer-session/listing-event/db/withListingEventCollectionSelectFx";
 import { withListingEventQueryBuilderFx } from "~/@buyer-session/listing-event/db/withListingEventQueryBuilderFx";
 import type { ListingEventCountQuerySchema } from "~/@buyer-session/listing-event/schema/ListingEventCountQuerySchema";
@@ -17,11 +18,9 @@ export const listingEventCountFx = Effect.fn("listingEventCountFx")(function* ({
 	scope,
 	count,
 }: listingEventCountFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingEventCountFx.filter": filter,
-		"listingEventCountFx.where": where,
-		"listingEventCountFx.scope": scope,
-		"listingEventCountFx.count": count,
+	yield* withTraceFx({
+		fx: "listingEventCountFx",
+		input: { filter, where, scope, count },
 	});
 
 	return yield* withCountFx({

--- a/apps/server/src/@buyer-session/listing-event/fx/listingEventCreateFx.ts
+++ b/apps/server/src/@buyer-session/listing-event/fx/listingEventCreateFx.ts
@@ -5,6 +5,7 @@ import { listingCheckIfOwnFx } from "~/@buyer-session/listing/fx/listingCheckIfO
 import { listingEventRateLimitFx } from "~/@buyer-session/listing-event/fx/listingEventRateLimitFx";
 import type { ListingEventCreateSchema } from "~/@buyer-session/listing-event/schema/ListingEventCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
 
 export namespace listingEventCreateFx {
@@ -18,10 +19,9 @@ export const listingEventCreateFx = Effect.fn("listingEventCreateFx")(function* 
 	listingId,
 	event,
 }: listingEventCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingEventCreateFx.userId": userId,
-		"listingEventCreateFx.listingId": listingId,
-		"listingEventCreateFx.event": event,
+	yield* withTraceFx({
+		fx: "listingEventCreateFx",
+		input: { userId, listingId, event },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-session/listing-event/fx/listingEventRateLimitFx.ts
+++ b/apps/server/src/@buyer-session/listing-event/fx/listingEventRateLimitFx.ts
@@ -2,7 +2,7 @@ import { DateContextFx } from "@use-pico/common/date";
 import { Effect } from "effect";
 import type { ListingEventEnumSchema } from "~/database/@enum/ListingEventEnumSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
-import { TooManyRequests } from "~/error/TooManyRequests";
+import { TooManyRequestsFx } from "~/error/TooManyRequestsFx";
 
 export namespace listingEventRateLimitFx {
 	export interface Props {
@@ -47,7 +47,7 @@ export const listingEventRateLimitFx = Effect.fn("listingEventRateLimitFx")(func
 	});
 
 	if (listingEvent) {
-		return yield* new TooManyRequests({
+		return yield* new TooManyRequestsFx({
 			message: "You have already created this event",
 		});
 	}

--- a/apps/server/src/@buyer-session/listing-event/fx/listingEventRateLimitFx.ts
+++ b/apps/server/src/@buyer-session/listing-event/fx/listingEventRateLimitFx.ts
@@ -2,6 +2,7 @@ import { DateContextFx } from "@use-pico/common/date";
 import { Effect } from "effect";
 import type { ListingEventEnumSchema } from "~/database/@enum/ListingEventEnumSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { TooManyRequestsFx } from "~/error/TooManyRequestsFx";
 
 export namespace listingEventRateLimitFx {
@@ -17,10 +18,9 @@ export const listingEventRateLimitFx = Effect.fn("listingEventRateLimitFx")(func
 	event,
 	minutes = 10,
 }: listingEventRateLimitFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingEventRateLimitFx.listingId": listingId,
-		"listingEventRateLimitFx.event": event,
-		"listingEventRateLimitFx.minutes": minutes,
+	yield* withTraceFx({
+		fx: "listingEventRateLimitFx",
+		input: { listingId, event, minutes },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@buyer-session/listing/fx/listingCheckIfOwnFx.ts
+++ b/apps/server/src/@buyer-session/listing/fx/listingCheckIfOwnFx.ts
@@ -1,7 +1,7 @@
 import { NotFoundErrorFx } from "@use-pico/common/error";
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace listingCheckIfOwnFx {
 	export interface Props {
@@ -44,7 +44,7 @@ export const listingCheckIfOwnFx = Effect.fn("listingCheckIfOwnFx")(function* ({
 	}
 
 	if (listing.userId === userId) {
-		return yield* new InvalidRequestError({
+		return yield* new InvalidRequestErrorFx({
 			message,
 		});
 	}

--- a/apps/server/src/@buyer-session/listing/fx/listingCheckIfOwnFx.ts
+++ b/apps/server/src/@buyer-session/listing/fx/listingCheckIfOwnFx.ts
@@ -1,6 +1,7 @@
 import { NotFoundErrorFx } from "@use-pico/common/error";
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace listingCheckIfOwnFx {
@@ -20,10 +21,9 @@ export const listingCheckIfOwnFx = Effect.fn("listingCheckIfOwnFx")(function* ({
 	listingId,
 	message,
 }: listingCheckIfOwnFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingCheckIfOwnFx.userId": userId,
-		"listingCheckIfOwnFx.listingId": listingId,
-		"listingCheckIfOwnFx.message": message,
+	yield* withTraceFx({
+		fx: "listingCheckIfOwnFx",
+		input: { userId, listingId, message },
 	});
 
 	const { kysely } = yield* KyselyContextFx;
@@ -36,6 +36,14 @@ export const listingCheckIfOwnFx = Effect.fn("listingCheckIfOwnFx")(function* ({
 	});
 
 	if (!listing) {
+		yield* withTraceFx({
+			fx: "listingCheckIfOwnFx",
+			error: {
+				resource: "listing",
+				resourceId: listingId,
+				message: "Listing not found",
+			},
+		});
 		return yield* new NotFoundErrorFx({
 			resource: "listing",
 			resourceId: listingId,
@@ -44,6 +52,10 @@ export const listingCheckIfOwnFx = Effect.fn("listingCheckIfOwnFx")(function* ({
 	}
 
 	if (listing.userId === userId) {
+		yield* withTraceFx({
+			fx: "listingCheckIfOwnFx",
+			error: { message },
+		});
 		return yield* new InvalidRequestErrorFx({
 			message,
 		});

--- a/apps/server/src/@buyer-session/listing/fx/listingGetSellerInfoFx.ts
+++ b/apps/server/src/@buyer-session/listing/fx/listingGetSellerInfoFx.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect";
 import { SellerInfoSchema } from "~/@buyer-session/listing/schema/SellerInfoSchema";
 import { userEventSellerInfoFx } from "~/@buyer-session/user-event/fx/userEventSellerInfoFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace listingGetSellerInfoFx {
 	export interface Props {
@@ -14,8 +15,9 @@ export namespace listingGetSellerInfoFx {
 export const listingGetSellerInfoFx = Effect.fn("listingGetSellerInfoFx")(function* ({
 	listingId,
 }: listingGetSellerInfoFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingGetSellerInfoFx.listingId": listingId,
+	yield* withTraceFx({
+		fx: "listingGetSellerInfoFx",
+		input: { listingId },
 	});
 
 	const { kysely } = yield* KyselyContextFx;
@@ -40,6 +42,13 @@ export const listingGetSellerInfoFx = Effect.fn("listingGetSellerInfoFx")(functi
 	});
 
 	if (!userInfo) {
+		yield* withTraceFx({
+			fx: "listingGetSellerInfoFx",
+			error: {
+				resource: "listing-seller-info",
+				message: "Seller info not available",
+			},
+		});
 		return yield* new NotFoundErrorFx({
 			resource: "listing-seller-info",
 			message: "Seller info not available",

--- a/apps/server/src/@buyer-session/user-event/fx/userEventBuyerInfoFx.ts
+++ b/apps/server/src/@buyer-session/user-event/fx/userEventBuyerInfoFx.ts
@@ -11,6 +11,7 @@ import { userEventCollectionFx } from "~/@common/user-event/fx/userEventCollecti
 import type { ActivityEnumSchema } from "~/@common/user-event/schema/ActivityEnumSchema";
 import type { LoadEnumSchema } from "~/@common/user-event/schema/LoadEnumSchema";
 import type { UserEventTableSchema } from "~/database/@table/UserEventTableSchema";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace userEventBuyerInfoFx {
 	export interface Props {
@@ -486,8 +487,9 @@ const computeScore = (input: {
 export const userEventBuyerInfoFx = Effect.fn("userEventBuyerInfoFx")(function* ({
 	userId,
 }: userEventBuyerInfoFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"userEventBuyerInfoFx.userId": userId,
+	yield* withTraceFx({
+		fx: "userEventBuyerInfoFx",
+		input: { userId },
 	});
 
 	const cutoff = 90;

--- a/apps/server/src/@buyer-session/user-event/fx/userEventSellerInfoFx.ts
+++ b/apps/server/src/@buyer-session/user-event/fx/userEventSellerInfoFx.ts
@@ -11,6 +11,7 @@ import { userEventCollectionFx } from "~/@common/user-event/fx/userEventCollecti
 import type { ActivityEnumSchema } from "~/@common/user-event/schema/ActivityEnumSchema";
 import type { LoadEnumSchema } from "~/@common/user-event/schema/LoadEnumSchema";
 import type { UserEventTableSchema } from "~/database/@table/UserEventTableSchema";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace userEventSellerInfoFx {
 	export interface Props {
@@ -512,8 +513,9 @@ const computeScore = (input: {
 export const userEventSellerInfoFx = Effect.fn("userEventSellerInfoFx")(function* ({
 	userId,
 }: userEventSellerInfoFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"userEventSellerInfoFx.userId": userId,
+	yield* withTraceFx({
+		fx: "userEventSellerInfoFx",
+		input: { userId },
 	});
 
 	const cutoff = 90;

--- a/apps/server/src/@buyer-user/favourite/fx/favouriteCreateFx.ts
+++ b/apps/server/src/@buyer-user/favourite/fx/favouriteCreateFx.ts
@@ -5,6 +5,7 @@ import { favouriteFetchFx } from "~/@buyer-user/favourite/fx/favouriteFetchFx";
 import type { FavouriteCreateSchema } from "~/@buyer-user/favourite/schema/FavouriteCreateSchema";
 import { feedFetchFx } from "~/@buyer-user/feed/fx/feedFetchFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace favouriteCreateFx {
 	export interface Props extends FavouriteCreateSchema.Type {
@@ -17,10 +18,9 @@ export const favouriteCreateFx = Effect.fn("favouriteCreateFx")(function* ({
 	feedId,
 	...data
 }: favouriteCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"favouriteCreateFx.userId": userId,
-		"favouriteCreateFx.feedId": feedId,
-		"favouriteCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "favouriteCreateFx",
+		input: { userId, feedId, ...data },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@buyer-user/favourite/fx/favouriteDeleteFx.ts
+++ b/apps/server/src/@buyer-user/favourite/fx/favouriteDeleteFx.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { favouriteFetchFx } from "~/@buyer-user/favourite/fx/favouriteFetchFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace favouriteDeleteFx {
 	export interface Props {
@@ -14,9 +15,9 @@ export const favouriteDeleteFx = Effect.fn("favouriteDeleteFx")(function* ({
 	userId,
 	listingId,
 }: favouriteDeleteFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"favouriteDeleteFx.userId": userId,
-		"favouriteDeleteFx.listingId": listingId,
+	yield* withTraceFx({
+		fx: "favouriteDeleteFx",
+		input: { userId, listingId },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/favourite/fx/favouriteToggleFx.ts
+++ b/apps/server/src/@buyer-user/favourite/fx/favouriteToggleFx.ts
@@ -6,6 +6,7 @@ import { favouriteDeleteFx } from "~/@buyer-user/favourite/fx/favouriteDeleteFx"
 import type { FavouriteToggleSchema } from "~/@buyer-user/favourite/schema/FavouriteToggleSchema";
 import { listingFetchFx } from "~/@buyer-user/listing/fx/listingFetchFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace favouriteToggleFx {
 	export interface Props extends FavouriteToggleSchema.Type {
@@ -19,11 +20,9 @@ export const favouriteToggleFx = Effect.fn("favouriteToggleFx")(function* ({
 	listingId,
 	toggle,
 }: favouriteToggleFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"favouriteToggleFx.userId": userId,
-		"favouriteToggleFx.feedId": feedId,
-		"favouriteToggleFx.listingId": listingId,
-		"favouriteToggleFx.toggle": toggle,
+	yield* withTraceFx({
+		fx: "favouriteToggleFx",
+		input: { userId, feedId, listingId, toggle },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/favourite/toggle.ts
+++ b/apps/server/src/@buyer-user/favourite/toggle.ts
@@ -100,7 +100,7 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@buyer-user/feed-gallery/create.ts
+++ b/apps/server/src/@buyer-user/feed-gallery/create.ts
@@ -100,13 +100,13 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				//
 				withDateFx,
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@buyer-user/feed-gallery/fx/feedGalleryCreateFx.ts
+++ b/apps/server/src/@buyer-user/feed-gallery/fx/feedGalleryCreateFx.ts
@@ -7,7 +7,7 @@ import { galleryFetchFx } from "~/@user/gallery/fx/galleryFetchFx";
 import { galleryItemCreateFx } from "~/@user/gallery-item/fx/galleryItemCreateFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace feedGalleryCreateFx {
 	export interface Props extends FeedGalleryCreateSchema.Type {
@@ -31,7 +31,7 @@ export const feedGalleryCreateFx = Effect.fn("feedGalleryCreateFx")(function* ({
 			});
 
 			if (uploadIds.length === 0) {
-				return yield* new InvalidRequestError({
+				return yield* new InvalidRequestErrorFx({
 					message: "At least one upload is required",
 				});
 			}

--- a/apps/server/src/@buyer-user/feed-gallery/fx/feedGalleryCreateFx.ts
+++ b/apps/server/src/@buyer-user/feed-gallery/fx/feedGalleryCreateFx.ts
@@ -7,6 +7,7 @@ import { galleryFetchFx } from "~/@user/gallery/fx/galleryFetchFx";
 import { galleryItemCreateFx } from "~/@user/gallery-item/fx/galleryItemCreateFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace feedGalleryCreateFx {
@@ -31,6 +32,12 @@ export const feedGalleryCreateFx = Effect.fn("feedGalleryCreateFx")(function* ({
 			});
 
 			if (uploadIds.length === 0) {
+				yield* withTraceFx({
+					fx: "feedGalleryCreateFx",
+					error: {
+						message: "At least one upload is required",
+					},
+				});
 				return yield* new InvalidRequestErrorFx({
 					message: "At least one upload is required",
 				});

--- a/apps/server/src/@buyer-user/feed/create.ts
+++ b/apps/server/src/@buyer-user/feed/create.ts
@@ -6,6 +6,7 @@ import { FeedCreateSchema } from "~/@buyer-user/feed/schema/FeedCreateSchema";
 import { FeedSchema } from "~/@buyer-user/feed/schema/FeedSchema";
 import { withLoggingFx } from "~/@common/axiom/fx/withLoggingFx";
 import { NotFoundNotice } from "~/@common/notice/NotFoundNotice";
+import { noticeError } from "~/@common/notice/noticeError";
 import { noticeZodError } from "~/@common/notice/noticeZodError";
 import { withDateFx } from "~/database/fx/withDateFx";
 import { withKyselyFx } from "~/database/fx/withKyselyFx";
@@ -94,6 +95,9 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					},
 					ZodErrorFx({ zod }) {
 						return c.json(noticeZodError(zod), 500);
+					},
+					RuntimeErrorFx(e) {
+						return c.json(noticeError(e), 500);
 					},
 				}),
 				Effect.runPromise,

--- a/apps/server/src/@buyer-user/feed/fx/feedCollectionFx.ts
+++ b/apps/server/src/@buyer-user/feed/fx/feedCollectionFx.ts
@@ -1,5 +1,6 @@
 import { withCollectionFx } from "@use-pico/common/collection";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withFeedCollectionSelectFx } from "~/@buyer-user/feed/db/withFeedCollectionSelectFx";
 import { withFeedQueryBuilderFx } from "~/@buyer-user/feed/db/withFeedQueryBuilderFx";
 import type { FeedFilterSchema } from "~/@buyer-user/feed/schema/FeedFilterSchema";
@@ -18,12 +19,9 @@ export const feedCollectionFx = Effect.fn("feedCollectionFx")(function* ({
 	cursor,
 	sort,
 }: feedCollectionFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"feedCollectionFx.filter": filter,
-		"feedCollectionFx.where": where,
-		"feedCollectionFx.scope": scope,
-		"feedCollectionFx.cursor": cursor,
-		"feedCollectionFx.sort": sort,
+	yield* withTraceFx({
+		fx: "feedCollectionFx",
+		input: { filter, where, scope, cursor, sort },
 	});
 
 	return yield* withCollectionFx({

--- a/apps/server/src/@buyer-user/feed/fx/feedCreateFx.ts
+++ b/apps/server/src/@buyer-user/feed/fx/feedCreateFx.ts
@@ -1,10 +1,12 @@
 import { DateContextFx } from "@use-pico/common/date";
 import { genId } from "@use-pico/common/gen-id";
 import { Effect } from "effect";
+import { DatabaseError } from "pg";
 import { feedFetchFx } from "~/@buyer-user/feed/fx/feedFetchFx";
 import type { FeedCreateSchema } from "~/@buyer-user/feed/schema/FeedCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { RuntimeErrorFx } from "~/error/RuntimeErrorFx";
 
 export namespace feedCreateFx {
 	export interface Props extends FeedCreateSchema.Type {
@@ -31,20 +33,33 @@ export const feedCreateFx = Effect.fn("feedCreateFx")(function* ({
 			const id = genId();
 			const now = dateContext.now();
 
-			yield* Effect.promise(async () => {
-				return kysely
-					.insertInto("feed")
-					.values({
-						...data,
-						id,
-						userId,
-						uploadId: null,
-						query: JSON.stringify(query) as any,
-						createdAt: now.toJSDate(),
-						updatedAt: now.toJSDate(),
-					})
-					.returningAll()
-					.executeTakeFirstOrThrow();
+			yield* Effect.tryPromise({
+				async try() {
+					return kysely
+						.insertInto("feed")
+						.values({
+							...data,
+							id,
+							userId,
+							uploadId: null,
+							query: JSON.stringify(query) as any,
+							createdAt: now.toJSDate(),
+							updatedAt: now.toJSDate(),
+						})
+						.returningAll()
+						.executeTakeFirstOrThrow();
+				},
+				catch(error) {
+					if (error instanceof DatabaseError) {
+						return new RuntimeErrorFx({
+							message: error.message,
+						});
+					}
+
+					return new RuntimeErrorFx({
+						message: error instanceof Error ? error.message : String(error),
+					});
+				},
 			});
 
 			return yield* feedFetchFx({

--- a/apps/server/src/@buyer-user/feed/fx/feedCreateFx.ts
+++ b/apps/server/src/@buyer-user/feed/fx/feedCreateFx.ts
@@ -6,6 +6,7 @@ import { feedFetchFx } from "~/@buyer-user/feed/fx/feedFetchFx";
 import type { FeedCreateSchema } from "~/@buyer-user/feed/schema/FeedCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { RuntimeErrorFx } from "~/error/RuntimeErrorFx";
 
 export namespace feedCreateFx {
@@ -19,10 +20,13 @@ export const feedCreateFx = Effect.fn("feedCreateFx")(function* ({
 	query,
 	...data
 }: feedCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"feedCreateFx.userId": userId,
-		"feedCreateFx.query": query,
-		"feedCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "feedCreateFx",
+		input: {
+			userId,
+			query,
+			...data,
+		},
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/feed/fx/feedDeleteFx.ts
+++ b/apps/server/src/@buyer-user/feed/fx/feedDeleteFx.ts
@@ -4,6 +4,7 @@ import type { FeedFilterSchema } from "~/@buyer-user/feed/schema/FeedFilterSchem
 import type { FeedQuerySchema } from "~/@buyer-user/feed/schema/FeedQuerySchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace feedDeleteFx {
 	export interface Props extends FeedQuerySchema.Type {
@@ -12,8 +13,9 @@ export namespace feedDeleteFx {
 }
 
 export const feedDeleteFx = Effect.fn("feedDeleteFx")(function* (query: feedDeleteFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"feedDeleteFx.query": query,
+	yield* withTraceFx({
+		fx: "feedDeleteFx",
+		input: { query },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/feed/fx/feedFetchFx.ts
+++ b/apps/server/src/@buyer-user/feed/fx/feedFetchFx.ts
@@ -4,6 +4,7 @@ import { withFeedQueryBuilderFx } from "~/@buyer-user/feed/db/withFeedQueryBuild
 import { withFeedSelectFx } from "~/@buyer-user/feed/db/withFeedSelectFx";
 import type { FeedFilterSchema } from "~/@buyer-user/feed/schema/FeedFilterSchema";
 import type { FeedQuerySchema } from "~/@buyer-user/feed/schema/FeedQuerySchema";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace feedFetchFx {
 	export interface Props extends FeedQuerySchema.Type {
@@ -17,11 +18,14 @@ export const feedFetchFx = Effect.fn("feedFetchFx")(function* ({
 	scope,
 	sort,
 }: feedFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"feedFetchFx.filter": filter,
-		"feedFetchFx.where": where,
-		"feedFetchFx.scope": scope,
-		"feedFetchFx.sort": sort,
+	yield* withTraceFx({
+		fx: "feedFetchFx",
+		input: {
+			filter,
+			where,
+			scope,
+			sort,
+		},
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@buyer-user/feed/fx/feedPatchFx.ts
+++ b/apps/server/src/@buyer-user/feed/fx/feedPatchFx.ts
@@ -5,6 +5,7 @@ import type { FeedFilterSchema } from "~/@buyer-user/feed/schema/FeedFilterSchem
 import type { FeedPatchSchema } from "~/@buyer-user/feed/schema/FeedPatchSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace feedPatchFx {
 	export interface Props extends FeedPatchSchema.Type {
@@ -17,10 +18,13 @@ export const feedPatchFx = Effect.fn("feedPatchFx")(function* ({
 	query,
 	scope,
 }: feedPatchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"feedPatchFx.patch": patch,
-		"feedPatchFx.query": query,
-		"feedPatchFx.scope": scope,
+	yield* withTraceFx({
+		fx: "feedPatchFx",
+		input: {
+			patch,
+			query,
+			scope,
+		},
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/feed/fx/feedResolveFx.ts
+++ b/apps/server/src/@buyer-user/feed/fx/feedResolveFx.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { feedFetchFx } from "~/@buyer-user/feed/fx/feedFetchFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { AccessDeniedErrorFx } from "~/error/AccessDeniedErrorFx";
 
 export namespace feedResolveFx {
@@ -25,6 +26,12 @@ export const feedResolveFx = Effect.fn("feedResolveFx")(function* ({
 	});
 
 	if (feed.userId !== userId) {
+		yield* withTraceFx({
+			fx: "feedResolveFx",
+			error: {
+				message,
+			},
+		});
 		return yield* new AccessDeniedErrorFx({
 			message,
 		});

--- a/apps/server/src/@buyer-user/feed/fx/feedResolveFx.ts
+++ b/apps/server/src/@buyer-user/feed/fx/feedResolveFx.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { feedFetchFx } from "~/@buyer-user/feed/fx/feedFetchFx";
-import { AccessDeniedError } from "~/error/AccessDeniedError";
+import { AccessDeniedErrorFx } from "~/error/AccessDeniedErrorFx";
 
 export namespace feedResolveFx {
 	export interface Props {
@@ -25,7 +25,7 @@ export const feedResolveFx = Effect.fn("feedResolveFx")(function* ({
 	});
 
 	if (feed.userId !== userId) {
-		return yield* new AccessDeniedError({
+		return yield* new AccessDeniedErrorFx({
 			message,
 		});
 	}

--- a/apps/server/src/@buyer-user/flag/fx/flagCreateFx.ts
+++ b/apps/server/src/@buyer-user/flag/fx/flagCreateFx.ts
@@ -3,6 +3,7 @@ import { genId } from "@use-pico/common/gen-id";
 import { Effect } from "effect";
 import type { FlagCreateSchema } from "~/@buyer-user/flag/schema/FlagCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace flagCreateFx {
 	export interface Props extends FlagCreateSchema.Type {
@@ -14,9 +15,9 @@ export const flagCreateFx = Effect.fn("flagCreateFx")(function* ({
 	userId,
 	listingId,
 }: flagCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"flagCreateFx.userId": userId,
-		"flagCreateFx.listingId": listingId,
+	yield* withTraceFx({
+		fx: "flagCreateFx",
+		input: { userId, listingId },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@buyer-user/flag/fx/flagDeleteFx.ts
+++ b/apps/server/src/@buyer-user/flag/fx/flagDeleteFx.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { flagFetchFx } from "~/@buyer-user/flag/fx/flagFetchFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace flagDeleteFx {
 	export interface Props {
@@ -14,9 +15,9 @@ export const flagDeleteFx = Effect.fn("flagDeleteFx")(function* ({
 	userId,
 	listingId,
 }: flagDeleteFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"flagDeleteFx.userId": userId,
-		"flagDeleteFx.listingId": listingId,
+	yield* withTraceFx({
+		fx: "flagDeleteFx",
+		input: { userId, listingId },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/flag/fx/flagToggleFx.ts
+++ b/apps/server/src/@buyer-user/flag/fx/flagToggleFx.ts
@@ -6,6 +6,7 @@ import { flagDeleteFx } from "~/@buyer-user/flag/fx/flagDeleteFx";
 import type { FlagToggleSchema } from "~/@buyer-user/flag/schema/FlagToggleSchema";
 import { listingFetchFx } from "~/@buyer-user/listing/fx/listingFetchFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace flagToggleFx {
 	export interface Props extends FlagToggleSchema.Type {
@@ -18,10 +19,9 @@ export const flagToggleFx = Effect.fn("flagToggleFx")(function* ({
 	toggle,
 	listingId,
 }: flagToggleFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"flagToggleFx.userId": userId,
-		"flagToggleFx.toggle": toggle,
-		"flagToggleFx.listingId": listingId,
+	yield* withTraceFx({
+		fx: "flagToggleFx",
+		input: { userId, toggle, listingId },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/flag/toggle.ts
+++ b/apps/server/src/@buyer-user/flag/toggle.ts
@@ -97,7 +97,7 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 				withLoggingFx(axiomConfig, "apiFlagToggle"),
 				withDateFx,
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {

--- a/apps/server/src/@buyer-user/ignore/fx/ignoreCreateFx.ts
+++ b/apps/server/src/@buyer-user/ignore/fx/ignoreCreateFx.ts
@@ -3,6 +3,7 @@ import { genId } from "@use-pico/common/gen-id";
 import { Effect } from "effect";
 import type { IgnoreCreateSchema } from "~/@buyer-user/ignore/schema/IgnoreCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace ignoreCreateFx {
 	export interface Props extends IgnoreCreateSchema.Type {
@@ -14,9 +15,9 @@ export const ignoreCreateFx = Effect.fn("ignoreCreateFx")(function* ({
 	userId,
 	listingId,
 }: ignoreCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"ignoreCreateFx.userId": userId,
-		"ignoreCreateFx.listingId": listingId,
+	yield* withTraceFx({
+		fx: "ignoreCreateFx",
+		input: { userId, listingId },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@buyer-user/ignore/fx/ignoreDeleteFx.ts
+++ b/apps/server/src/@buyer-user/ignore/fx/ignoreDeleteFx.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { ignoreFetchFx } from "~/@buyer-user/ignore/fx/ignoreFetchFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace ignoreDeleteFx {
 	export interface Props {
@@ -14,9 +15,9 @@ export const ignoreDeleteFx = Effect.fn("ignoreDeleteFx")(function* ({
 	userId,
 	listingId,
 }: ignoreDeleteFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"ignoreDeleteFx.userId": userId,
-		"ignoreDeleteFx.listingId": listingId,
+	yield* withTraceFx({
+		fx: "ignoreDeleteFx",
+		input: { userId, listingId },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/ignore/fx/ignoreToggleFx.ts
+++ b/apps/server/src/@buyer-user/ignore/fx/ignoreToggleFx.ts
@@ -6,6 +6,7 @@ import { ignoreDeleteFx } from "~/@buyer-user/ignore/fx/ignoreDeleteFx";
 import type { IgnoreToggleSchema } from "~/@buyer-user/ignore/schema/IgnoreToggleSchema";
 import { listingFetchFx } from "~/@buyer-user/listing/fx/listingFetchFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace ignoreToggleFx {
 	export interface Props extends IgnoreToggleSchema.Type {
@@ -18,10 +19,9 @@ export const ignoreToggleFx = Effect.fn("ignoreToggleFx")(function* ({
 	toggle,
 	listingId,
 }: ignoreToggleFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"ignoreToggleFx.userId": userId,
-		"ignoreToggleFx.toggle": toggle,
-		"ignoreToggleFx.listingId": listingId,
+	yield* withTraceFx({
+		fx: "ignoreToggleFx",
+		input: { userId, toggle, listingId },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/ignore/toggle.ts
+++ b/apps/server/src/@buyer-user/ignore/toggle.ts
@@ -97,7 +97,7 @@ export const withToggleApiFx = Effect.fn("withToggleApiFx")(function* () {
 				withLoggingFx(axiomConfig, "apiIgnoreToggle"),
 				withDateFx,
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {

--- a/apps/server/src/@buyer-user/listing/fx/listingCollectionFx.ts
+++ b/apps/server/src/@buyer-user/listing/fx/listingCollectionFx.ts
@@ -1,5 +1,6 @@
 import { withCollectionFx } from "@use-pico/common/collection";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withListingCollectionSelectFx } from "~/@buyer-user/listing/db/withListingCollectionSelectFx";
 import { withListingQueryBuilderFx } from "~/@buyer-user/listing/db/withListingQueryBuilderFx";
 import type { ListingFilterSchema } from "~/@buyer-user/listing/schema/ListingFilterSchema";
@@ -21,14 +22,9 @@ export const listingCollectionFx = Effect.fn("listingCollectionFx")(function* ({
 	sort,
 	meta,
 }: listingCollectionFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingCollectionFx.userId": userId,
-		"listingCollectionFx.cursor": cursor,
-		"listingCollectionFx.filter": filter,
-		"listingCollectionFx.where": where,
-		"listingCollectionFx.scope": scope,
-		"listingCollectionFx.sort": sort,
-		"listingCollectionFx.meta": meta,
+	yield* withTraceFx({
+		fx: "listingCollectionFx",
+		input: { userId, cursor, filter, where, scope, sort, meta },
 	});
 
 	return yield* withCollectionFx({

--- a/apps/server/src/@buyer-user/listing/fx/listingCountFx.ts
+++ b/apps/server/src/@buyer-user/listing/fx/listingCountFx.ts
@@ -1,5 +1,6 @@
 import { withCountFx } from "@use-pico/common/count";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withListingCollectionSelectFx } from "~/@buyer-user/listing/db/withListingCollectionSelectFx";
 import { withListingQueryBuilderFx } from "~/@buyer-user/listing/db/withListingQueryBuilderFx";
 import type { ListingCountQuerySchema } from "~/@buyer-user/listing/schema/ListingCountQuerySchema";
@@ -19,12 +20,9 @@ export const listingCountFx = Effect.fn("listingCountFx")(function* ({
 	scope,
 	meta,
 }: listingCountFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingCountFx.userId": userId,
-		"listingCountFx.filter": filter,
-		"listingCountFx.where": where,
-		"listingCountFx.scope": scope,
-		"listingCountFx.meta": meta,
+	yield* withTraceFx({
+		fx: "listingCountFx",
+		input: { userId, filter, where, scope, meta },
 	});
 
 	return yield* withCountFx({

--- a/apps/server/src/@buyer-user/listing/fx/listingFetchFx.ts
+++ b/apps/server/src/@buyer-user/listing/fx/listingFetchFx.ts
@@ -4,6 +4,7 @@ import { withListingQueryBuilderFx } from "~/@buyer-user/listing/db/withListingQ
 import { withListingSelectFx } from "~/@buyer-user/listing/db/withListingSelectFx";
 import type { ListingFilterSchema } from "~/@buyer-user/listing/schema/ListingFilterSchema";
 import type { ListingQuerySchema } from "~/@buyer-user/listing/schema/ListingQuerySchema";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace listingFetchFx {
 	export interface Props extends ListingQuerySchema.Type {
@@ -20,13 +21,9 @@ export const listingFetchFx = Effect.fn("listingFetchFx")(function* ({
 	sort,
 	meta,
 }: listingFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingFetchFx.userId": userId,
-		"listingFetchFx.filter": filter,
-		"listingFetchFx.where": where,
-		"listingFetchFx.scope": scope,
-		"listingFetchFx.sort": sort,
-		"listingFetchFx.meta": meta,
+	yield* withTraceFx({
+		fx: "listingFetchFx",
+		input: { userId, filter, where, scope, sort, meta },
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@buyer-user/thumb/create.ts
+++ b/apps/server/src/@buyer-user/thumb/create.ts
@@ -98,7 +98,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				withLoggingFx(axiomConfig, "apiThumbCreate"),
 				withDateFx,
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {

--- a/apps/server/src/@buyer-user/thumb/fx/thumbCreateFx.ts
+++ b/apps/server/src/@buyer-user/thumb/fx/thumbCreateFx.ts
@@ -6,6 +6,7 @@ import { listingEventCreateFx } from "~/@buyer-session/listing-event/fx/listingE
 import { listingFetchFx } from "~/@buyer-user/listing/fx/listingFetchFx";
 import type { ThumbCreateSchema } from "~/@buyer-user/thumb/schema/ThumbCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
 
 export namespace thumbCreateFx {
@@ -20,11 +21,9 @@ export const thumbCreateFx = Effect.fn("thumbCreateFx")(function* ({
 	type,
 	...data
 }: thumbCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"thumbCreateFx.userId": userId,
-		"thumbCreateFx.listingId": listingId,
-		"thumbCreateFx.type": type,
-		"thumbCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "thumbCreateFx",
+		input: { userId, listingId, type, ...data },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@buyer-user/transaction-status/close.ts
+++ b/apps/server/src/@buyer-user/transaction-status/close.ts
@@ -103,10 +103,10 @@ export const withCloseApiFx = Effect.fn("withCloseApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@buyer-user/transaction-status/close.ts
+++ b/apps/server/src/@buyer-user/transaction-status/close.ts
@@ -109,7 +109,7 @@ export const withCloseApiFx = Effect.fn("withCloseApiFx")(function* () {
 					InvalidRequestError(e) {
 						return c.json(noticeError(e), 400);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@buyer-user/transaction-status/dispute.ts
+++ b/apps/server/src/@buyer-user/transaction-status/dispute.ts
@@ -109,7 +109,7 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 					InvalidRequestError(e) {
 						return c.json(noticeError(e), 400);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@buyer-user/transaction-status/dispute.ts
+++ b/apps/server/src/@buyer-user/transaction-status/dispute.ts
@@ -103,10 +103,10 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusCloseFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusCloseFx.ts
@@ -6,6 +6,7 @@ import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCr
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusCloseFx {
@@ -18,9 +19,9 @@ export const transactionStatusCloseFx = Effect.fn("transactionStatusCloseFx")(fu
 	userId,
 	transactionId,
 }: transactionStatusCloseFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusCloseFx.userId": userId,
-		"transactionStatusCloseFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionStatusCloseFx",
+		input: { userId, transactionId },
 	});
 
 	return yield* withTransactionFx(
@@ -32,6 +33,10 @@ export const transactionStatusCloseFx = Effect.fn("transactionStatusCloseFx")(fu
 			});
 
 			if (transaction.side === "seller") {
+				yield* withTraceFx({
+					fx: "transactionStatusCloseFx",
+					error: { message: "Seller cannot close a transaction" },
+				});
 				return yield* new InvalidRequestErrorFx({
 					message: "Seller cannot close a transaction",
 				});

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusCloseFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusCloseFx.ts
@@ -6,7 +6,7 @@ import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCr
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusCloseFx {
 	export interface Props extends TransactionStatusCloseSchema.Type {
@@ -32,7 +32,7 @@ export const transactionStatusCloseFx = Effect.fn("transactionStatusCloseFx")(fu
 			});
 
 			if (transaction.side === "seller") {
-				return yield* new InvalidRequestError({
+				return yield* new InvalidRequestErrorFx({
 					message: "Seller cannot close a transaction",
 				});
 			}

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusCreateFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusCreateFx.ts
@@ -5,6 +5,7 @@ import { transactionPatchFx } from "~/@buyer-user/transaction/fx/transactionPatc
 import type { TransactionStatusCreateSchema } from "~/@common/transaction-status/schema/TransactionStatusCreateSchema";
 import { transactionStatusFetchFx } from "~/@session/transaction-status/fx/transactionStatusFetchFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionStatusCreateFx {
 	export interface Props extends TransactionStatusCreateSchema.Type {
@@ -17,9 +18,9 @@ export const transactionStatusCreateFx = Effect.fn("transactionStatusCreateFx")(
 	userId,
 	...create
 }: transactionStatusCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusCreateFx.userId": userId,
-		"transactionStatusCreateFx.create": create,
+	yield* withTraceFx({
+		fx: "transactionStatusCreateFx",
+		input: { userId, ...create },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusDisputeFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusDisputeFx.ts
@@ -4,6 +4,7 @@ import { transactionStatusCreateFx } from "~/@buyer-user/transaction-status/fx/t
 import type { TransactionStatusDisputeSchema } from "~/@common/transaction-status/schema/TransactionStatusDisputeSchema";
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusDisputeFx {
@@ -16,9 +17,9 @@ export const transactionStatusDisputeFx = Effect.fn("transactionStatusDisputeFx"
 	userId,
 	transactionId,
 }: transactionStatusDisputeFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusDisputeFx.userId": userId,
-		"transactionStatusDisputeFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionStatusDisputeFx",
+		input: { userId, transactionId },
 	});
 
 	const transaction = yield* transactionResolveFx({
@@ -28,6 +29,12 @@ export const transactionStatusDisputeFx = Effect.fn("transactionStatusDisputeFx"
 	});
 
 	if (transaction.side !== "buyer") {
+		yield* withTraceFx({
+			fx: "transactionStatusDisputeFx",
+			error: {
+				message: "Only buyer can dispute a transaction from buyer-user endpoint",
+			},
+		});
 		return yield* new InvalidRequestErrorFx({
 			message: "Only buyer can dispute a transaction from buyer-user endpoint",
 		});

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusDisputeFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusDisputeFx.ts
@@ -4,7 +4,7 @@ import { transactionStatusCreateFx } from "~/@buyer-user/transaction-status/fx/t
 import type { TransactionStatusDisputeSchema } from "~/@common/transaction-status/schema/TransactionStatusDisputeSchema";
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusDisputeFx {
 	export interface Props extends TransactionStatusDisputeSchema.Type {
@@ -28,7 +28,7 @@ export const transactionStatusDisputeFx = Effect.fn("transactionStatusDisputeFx"
 	});
 
 	if (transaction.side !== "buyer") {
-		return yield* new InvalidRequestError({
+		return yield* new InvalidRequestErrorFx({
 			message: "Only buyer can dispute a transaction from buyer-user endpoint",
 		});
 	}

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusRejectFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusRejectFx.ts
@@ -5,7 +5,7 @@ import type { TransactionStatusRejectSchema } from "~/@common/transaction-status
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusRejectFx {
 	export interface Props extends TransactionStatusRejectSchema.Type {
@@ -29,7 +29,7 @@ export const transactionStatusRejectFx = Effect.fn("transactionStatusRejectFx")(
 	});
 
 	if (transaction.side !== "buyer") {
-		return yield* new InvalidRequestError({
+		return yield* new InvalidRequestErrorFx({
 			message: "Only buyer can reject a transaction from buyer-user endpoint",
 		});
 	}

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusRejectFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusRejectFx.ts
@@ -5,6 +5,7 @@ import type { TransactionStatusRejectSchema } from "~/@common/transaction-status
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusRejectFx {
@@ -17,9 +18,9 @@ export const transactionStatusRejectFx = Effect.fn("transactionStatusRejectFx")(
 	userId,
 	transactionId,
 }: transactionStatusRejectFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusRejectFx.userId": userId,
-		"transactionStatusRejectFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionStatusRejectFx",
+		input: { userId, transactionId },
 	});
 
 	const transaction = yield* transactionResolveFx({
@@ -29,6 +30,12 @@ export const transactionStatusRejectFx = Effect.fn("transactionStatusRejectFx")(
 	});
 
 	if (transaction.side !== "buyer") {
+		yield* withTraceFx({
+			fx: "transactionStatusRejectFx",
+			error: {
+				message: "Only buyer can reject a transaction from buyer-user endpoint",
+			},
+		});
 		return yield* new InvalidRequestErrorFx({
 			message: "Only buyer can reject a transaction from buyer-user endpoint",
 		});

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusSuccessFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusSuccessFx.ts
@@ -6,7 +6,7 @@ import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCr
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusSuccessFx {
 	export interface Props extends TransactionStatusSuccessSchema.Type {
@@ -32,7 +32,7 @@ export const transactionStatusSuccessFx = Effect.fn("transactionStatusSuccessFx"
 			});
 
 			if (transaction.side === "seller") {
-				return yield* new InvalidRequestError({
+				return yield* new InvalidRequestErrorFx({
 					message: "Seller cannot mark a transaction as successful",
 				});
 			}

--- a/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusSuccessFx.ts
+++ b/apps/server/src/@buyer-user/transaction-status/fx/transactionStatusSuccessFx.ts
@@ -6,6 +6,7 @@ import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCr
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusSuccessFx {
@@ -18,9 +19,9 @@ export const transactionStatusSuccessFx = Effect.fn("transactionStatusSuccessFx"
 	userId,
 	transactionId,
 }: transactionStatusSuccessFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusSuccessFx.userId": userId,
-		"transactionStatusSuccessFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionStatusSuccessFx",
+		input: { userId, transactionId },
 	});
 
 	return yield* withTransactionFx(
@@ -32,6 +33,12 @@ export const transactionStatusSuccessFx = Effect.fn("transactionStatusSuccessFx"
 			});
 
 			if (transaction.side === "seller") {
+				yield* withTraceFx({
+					fx: "transactionStatusSuccessFx",
+					error: {
+						message: "Seller cannot mark a transaction as successful",
+					},
+				});
 				return yield* new InvalidRequestErrorFx({
 					message: "Seller cannot mark a transaction as successful",
 				});

--- a/apps/server/src/@buyer-user/transaction-status/reject.ts
+++ b/apps/server/src/@buyer-user/transaction-status/reject.ts
@@ -109,7 +109,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 					InvalidRequestError(e) {
 						return c.json(noticeError(e), 400);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@buyer-user/transaction-status/reject.ts
+++ b/apps/server/src/@buyer-user/transaction-status/reject.ts
@@ -103,10 +103,10 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@buyer-user/transaction-status/success.ts
+++ b/apps/server/src/@buyer-user/transaction-status/success.ts
@@ -110,7 +110,7 @@ export const withSuccessApiFx = Effect.fn("withSuccessApiFx")(function* () {
 					InvalidRequestError(e) {
 						return c.json(noticeError(e), 400);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@buyer-user/transaction-status/success.ts
+++ b/apps/server/src/@buyer-user/transaction-status/success.ts
@@ -104,10 +104,10 @@ export const withSuccessApiFx = Effect.fn("withSuccessApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@buyer-user/transaction/fx/transactionCollectionFx.ts
+++ b/apps/server/src/@buyer-user/transaction/fx/transactionCollectionFx.ts
@@ -4,6 +4,7 @@ import { withTransactionCollectionSelectFx } from "~/@buyer-user/transaction/db/
 import { withTransactionQueryBuilderFx } from "~/@buyer-user/transaction/db/withTransactionQueryBuilderFx";
 import type { TransactionFilterSchema } from "~/@common/transaction/schema/TransactionFilterSchema";
 import type { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionCollectionFx {
 	export interface Props extends TransactionQuerySchema.Type {
@@ -18,12 +19,15 @@ export const transactionCollectionFx = Effect.fn("transactionCollectionFx")(func
 	cursor,
 	sort,
 }: transactionCollectionFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionCollectionFx.filter": filter,
-		"transactionCollectionFx.where": where,
-		"transactionCollectionFx.scope": scope,
-		"transactionCollectionFx.cursor": cursor,
-		"transactionCollectionFx.sort": sort,
+	yield* withTraceFx({
+		fx: "transactionCollectionFx",
+		input: {
+			filter,
+			where,
+			scope,
+			cursor,
+			sort,
+		},
 	});
 
 	return yield* withCollectionFx({

--- a/apps/server/src/@buyer-user/transaction/fx/transactionCreateFx.ts
+++ b/apps/server/src/@buyer-user/transaction/fx/transactionCreateFx.ts
@@ -13,6 +13,7 @@ import { messageUserCreateFx } from "~/@user/message-thread-user/fx/messageUserC
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionCreateFx {
 	export interface Props extends TransactionCreateSchema.Type {
@@ -25,10 +26,9 @@ export const transactionCreateFx = Effect.fn("transactionCreateFx")(function* ({
 	listingId,
 	...data
 }: transactionCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionCreateFx.userId": userId,
-		"transactionCreateFx.listingId": listingId,
-		"transactionCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "transactionCreateFx",
+		input: { userId, listingId, ...data },
 	});
 
 	return yield* withTransactionFx(
@@ -49,6 +49,14 @@ export const transactionCreateFx = Effect.fn("transactionCreateFx")(function* ({
 			});
 
 			if (!listing) {
+				yield* withTraceFx({
+					fx: "transactionCreateFx",
+					error: {
+						resource: "listing",
+						resourceId: listingId,
+						message: "Listing not found",
+					},
+				});
 				return yield* new NotFoundErrorFx({
 					resource: "listing",
 					resourceId: listingId,

--- a/apps/server/src/@buyer-user/transaction/fx/transactionFetchFx.ts
+++ b/apps/server/src/@buyer-user/transaction/fx/transactionFetchFx.ts
@@ -1,5 +1,6 @@
 import { withFetchFx } from "@use-pico/common/fetch";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withTransactionQueryBuilderFx } from "~/@buyer-user/transaction/db/withTransactionQueryBuilderFx";
 import { withTransactionSelectFx } from "~/@buyer-user/transaction/db/withTransactionSelectFx";
 import type { TransactionFilterSchema } from "~/@common/transaction/schema/TransactionFilterSchema";
@@ -17,11 +18,9 @@ export const transactionFetchFx = Effect.fn("transactionFetchFx")(function* ({
 	scope,
 	sort,
 }: transactionFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionFetchFx.filter": filter,
-		"transactionFetchFx.where": where,
-		"transactionFetchFx.scope": scope,
-		"transactionFetchFx.sort": sort,
+	yield* withTraceFx({
+		fx: "transactionFetchFx",
+		input: { filter, where, scope, sort },
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@buyer-user/transaction/fx/transactionPatchFx.ts
+++ b/apps/server/src/@buyer-user/transaction/fx/transactionPatchFx.ts
@@ -6,6 +6,7 @@ import { TransactionContextFx } from "~/@common/transaction/context/TransactionC
 import type { TransactionFilterSchema } from "~/@common/transaction/schema/TransactionFilterSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionPatchFx {
 	export interface Props extends TransactionPatchSchema.Type {
@@ -20,11 +21,9 @@ export const transactionPatchFx = Effect.fn("transactionPatchFx")(function* ({
 	query,
 	scope,
 }: transactionPatchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionPatchFx.userId": userId,
-		"transactionPatchFx.patch": patch,
-		"transactionPatchFx.query": query,
-		"transactionPatchFx.scope": scope,
+	yield* withTraceFx({
+		fx: "transactionPatchFx",
+		input: { userId, patch, query, scope },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@common/axiom/fx/withLoggingFx.ts
+++ b/apps/server/src/@common/axiom/fx/withLoggingFx.ts
@@ -17,7 +17,15 @@ export const withLoggingFx =
 					return yield* Effect.logError(name);
 				});
 			}),
-			Effect.tapDefect(() => Effect.logFatal(name)),
+			Effect.tapDefect((e) => {
+				return Effect.gen(function* () {
+					yield* Effect.annotateLogsScoped({
+						$fatal: e,
+					});
+
+					return yield* Effect.logFatal(name);
+				});
+			}),
 			//
 			Effect.withLogSpan("runtime"),
 			Effect.provide(AxiomLoggerLayer),

--- a/apps/server/src/@common/axiom/fx/withLoggingFx.ts
+++ b/apps/server/src/@common/axiom/fx/withLoggingFx.ts
@@ -8,7 +8,15 @@ export const withLoggingFx =
 	<A, E, R>(eff: Effect.Effect<A, E, R>) =>
 		eff.pipe(
 			Effect.tap(() => Effect.log(name)),
-			Effect.tapError(() => Effect.logError(name)),
+			Effect.tapError((e) => {
+				return Effect.gen(function* () {
+					yield* Effect.annotateLogsScoped({
+						$catch: e,
+					});
+
+					return yield* Effect.logError(name);
+				});
+			}),
 			Effect.tapDefect(() => Effect.logFatal(name)),
 			//
 			Effect.withLogSpan("runtime"),

--- a/apps/server/src/@common/s3/fx/s3PreSignFx.ts
+++ b/apps/server/src/@common/s3/fx/s3PreSignFx.ts
@@ -2,6 +2,7 @@ import { genId } from "@use-pico/common/gen-id";
 import { keyOf } from "@use-pico/common/key-of";
 import { linkTo } from "@use-pico/common/link-to";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { S3ContextFx } from "~/@common/s3/context/S3ContextFx";
 import { s3ClientFx } from "~/@common/s3/fx/s3ClientFx";
 import { UploadContextFx } from "~/@common/upload/context/UploadContextFx";
@@ -19,10 +20,9 @@ export const s3PreSignFx = Effect.fn("s3PreSignFx")(function* ({
 	path,
 	extension,
 }: s3PreSignFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"s3PreSignFx.userId": userId,
-		"s3PreSignFx.path": path,
-		"s3PreSignFx.extension": extension,
+	yield* withTraceFx({
+		fx: "s3PreSignFx",
+		input: { userId, path, extension },
 	});
 
 	const { cdn } = yield* UploadContextFx;

--- a/apps/server/src/@common/user-event/fx/userEventCollectionFx.ts
+++ b/apps/server/src/@common/user-event/fx/userEventCollectionFx.ts
@@ -1,5 +1,6 @@
 import { withCollectionFx } from "@use-pico/common/collection";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withUserEventCollectionSelectFx } from "~/@common/user-event/db/withUserEventCollectionSelectFx";
 import { withUserEventQueryBuilderFx } from "~/@common/user-event/db/withUserEventQueryBuilderFx";
 import type { UserEventFilterSchema } from "~/@common/user-event/schema/UserEventFilterSchema";
@@ -18,12 +19,9 @@ export const userEventCollectionFx = Effect.fn("userEventCollectionFx")(function
 	cursor,
 	sort,
 }: userEventCollectionFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"userEventCollectionFx.filter": filter,
-		"userEventCollectionFx.where": where,
-		"userEventCollectionFx.scope": scope,
-		"userEventCollectionFx.cursor": cursor,
-		"userEventCollectionFx.sort": sort,
+	yield* withTraceFx({
+		fx: "userEventCollectionFx",
+		input: { filter, where, scope, cursor, sort },
 	});
 
 	return yield* withCollectionFx({

--- a/apps/server/src/@public/seed/fx/listingOfFx.ts
+++ b/apps/server/src/@public/seed/fx/listingOfFx.ts
@@ -1,6 +1,7 @@
 import { z } from "@hono/zod-openapi";
 import { list, rangedom } from "@use-pico/common/rangedom";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { listingCollectionFx } from "~/@buyer-user/listing/fx/listingCollectionFx";
 import { listingCountFx } from "~/@buyer-user/listing/fx/listingCountFx";
 import type { ListingSortSchema } from "~/@buyer-user/listing/schema/ListingSortSchema";
@@ -24,9 +25,9 @@ export const listingOfFx = Effect.fn("listingOfFx")(function* ({
 	userId,
 	count,
 }: ListingOfRequestSchema.Type) {
-	yield* Effect.annotateLogsScoped({
-		"listingOfFx.userId": userId,
-		"listingOfFx.count": count,
+	yield* withTraceFx({
+		fx: "listingOfFx",
+		input: { userId, count },
 	});
 
 	const total = yield* listingCountFx({

--- a/apps/server/src/@public/seed/fx/seedFx.ts
+++ b/apps/server/src/@public/seed/fx/seedFx.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { seedTransactionInteractionFx } from "~/@public/seed/fx/seedTransactionInteractionFx";
 import { SeedTransactionsRequestSchema } from "~/@public/seed/fx/seedTransactionsFx";
 import { seedUserFx } from "~/@public/seed/fx/seedUserFx";
@@ -23,9 +24,9 @@ export const seedFx = Effect.fn("seedFx")(function* ({
 	email,
 	transaction,
 }: SeedRequestSchema.Type) {
-	yield* Effect.annotateLogsScoped({
-		"seedFx.email": email,
-		"seedFx.transaction": transaction,
+	yield* withTraceFx({
+		fx: "seedFx",
+		input: { email, transaction },
 	});
 
 	const current = yield* seedUserFx({

--- a/apps/server/src/@public/seed/fx/seedUserFx.ts
+++ b/apps/server/src/@public/seed/fx/seedUserFx.ts
@@ -1,6 +1,7 @@
 import { NotFoundErrorFx } from "@use-pico/common/error";
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace seedUserFx {
 	export interface Props {
@@ -16,6 +17,14 @@ export const seedUserFx = Effect.fn("seedUserFx")(function* ({ email }: seedUser
 	});
 
 	if (!current) {
+		yield* withTraceFx({
+			fx: "seedUserFx",
+			error: {
+				resource: "user",
+				resourceId: email,
+				message: "User not found",
+			},
+		});
 		return yield* new NotFoundErrorFx({
 			resource: "user",
 			resourceId: email,

--- a/apps/server/src/@public/seed/seed.ts
+++ b/apps/server/src/@public/seed/seed.ts
@@ -97,7 +97,7 @@ export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					RuntimeError(err) {
+					RuntimeErrorFx(err) {
 						return c.json(noticeError(err), 500);
 					},
 				}),

--- a/apps/server/src/@public/seed/seed.ts
+++ b/apps/server/src/@public/seed/seed.ts
@@ -88,10 +88,10 @@ export const withSeedApiFx = Effect.fn("withSeedApiFx")(function* () {
 				}),
 				withLoggingFx(axiomConfig, "apiSeed"),
 				withCatchFx({
-					InvalidRequestError(err) {
+					InvalidRequestErrorFx(err) {
 						return c.json(noticeError(err), 400);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					NotFoundErrorFx() {

--- a/apps/server/src/@seller-session/transaction/fx/transactionGetBuyerInfoFx.ts
+++ b/apps/server/src/@seller-session/transaction/fx/transactionGetBuyerInfoFx.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect";
 import { userEventBuyerInfoFx } from "~/@buyer-session/user-event/fx/userEventBuyerInfoFx";
 import { TransactionBuyerInfoSchema } from "~/@seller-session/transaction/schema/TransactionBuyerInfoSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionGetBuyerInfoFx {
 	export interface Props {
@@ -16,9 +17,9 @@ export const transactionGetBuyerInfoFx = Effect.fn("transactionGetBuyerInfoFx")(
 	userId,
 	transactionId,
 }: transactionGetBuyerInfoFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionGetBuyerInfoFx.userId": userId,
-		"transactionGetBuyerInfoFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionGetBuyerInfoFx",
+		input: { userId, transactionId },
 	});
 
 	const { kysely } = yield* KyselyContextFx;
@@ -46,6 +47,13 @@ export const transactionGetBuyerInfoFx = Effect.fn("transactionGetBuyerInfoFx")(
 	});
 
 	if (!userInfo) {
+		yield* withTraceFx({
+			fx: "transactionGetBuyerInfoFx",
+			error: {
+				resource: "transaction-buyer-info",
+				message: "Buyer info not available",
+			},
+		});
 		return yield* new NotFoundErrorFx({
 			resource: "transaction-buyer-info",
 			message: "Buyer info not available",

--- a/apps/server/src/@seller-user/draft-gallery/create.ts
+++ b/apps/server/src/@seller-user/draft-gallery/create.ts
@@ -98,13 +98,13 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				withKyselyFx(c.get("kysely")),
 				withDateFx,
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@seller-user/draft-gallery/fx/draftGalleryCreateFx.ts
+++ b/apps/server/src/@seller-user/draft-gallery/fx/draftGalleryCreateFx.ts
@@ -5,6 +5,7 @@ import { galleryFetchFx } from "~/@user/gallery/fx/galleryFetchFx";
 import { galleryItemCreateFx } from "~/@user/gallery-item/fx/galleryItemCreateFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace draftGalleryCreateFx {
@@ -23,6 +24,12 @@ export const draftGalleryCreateFx = Effect.fn("draftGalleryCreateFx")(function* 
 			const { kysely } = yield* KyselyContextFx;
 
 			if (uploadIds.length === 0) {
+				yield* withTraceFx({
+					fx: "draftGalleryCreateFx",
+					error: {
+						message: "At least one upload is required",
+					},
+				});
 				return yield* new InvalidRequestErrorFx({
 					message: "At least one upload is required",
 				});

--- a/apps/server/src/@seller-user/draft-gallery/fx/draftGalleryCreateFx.ts
+++ b/apps/server/src/@seller-user/draft-gallery/fx/draftGalleryCreateFx.ts
@@ -5,7 +5,7 @@ import { galleryFetchFx } from "~/@user/gallery/fx/galleryFetchFx";
 import { galleryItemCreateFx } from "~/@user/gallery-item/fx/galleryItemCreateFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace draftGalleryCreateFx {
 	export interface Props extends DraftGalleryCreateSchema.Type {
@@ -23,7 +23,7 @@ export const draftGalleryCreateFx = Effect.fn("draftGalleryCreateFx")(function* 
 			const { kysely } = yield* KyselyContextFx;
 
 			if (uploadIds.length === 0) {
-				return yield* new InvalidRequestError({
+				return yield* new InvalidRequestErrorFx({
 					message: "At least one upload is required",
 				});
 			}

--- a/apps/server/src/@seller-user/draft/fx/draftCreateFx.ts
+++ b/apps/server/src/@seller-user/draft/fx/draftCreateFx.ts
@@ -7,6 +7,7 @@ import { galleryCreateFx as coolGalleryCreateFx } from "~/@user/gallery/fx/galle
 import { galleryItemCreateFx } from "~/@user/gallery-item/fx/galleryItemCreateFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace draftCreateFx {
 	export interface Props extends DraftCreateSchema.Type {
@@ -18,9 +19,9 @@ export const draftCreateFx = Effect.fn("draftCreateFx")(function* ({
 	userId,
 	...data
 }: draftCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"draftCreateFx.userId": userId,
-		"draftCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "draftCreateFx",
+		input: { userId, ...data },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@seller-user/draft/fx/draftDeleteFx.ts
+++ b/apps/server/src/@seller-user/draft/fx/draftDeleteFx.ts
@@ -4,6 +4,7 @@ import type { DraftFilterSchema } from "~/@seller-user/draft/schema/DraftFilterS
 import type { DraftQuerySchema } from "~/@seller-user/draft/schema/DraftQuerySchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace draftDeleteFx {
 	export interface Props extends Omit<DraftQuerySchema.Type, "cursor" | "sort"> {
@@ -12,8 +13,9 @@ export namespace draftDeleteFx {
 }
 
 export const draftDeleteFx = Effect.fn("draftDeleteFx")(function* (query: draftDeleteFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"draftDeleteFx.query": query,
+	yield* withTraceFx({
+		fx: "draftDeleteFx",
+		input: { query },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@seller-user/draft/fx/draftFetchFx.ts
+++ b/apps/server/src/@seller-user/draft/fx/draftFetchFx.ts
@@ -4,6 +4,7 @@ import { withDraftQueryBuilderFx } from "~/@seller-user/draft/db/withDraftQueryB
 import { withDraftSelectFx } from "~/@seller-user/draft/db/withDraftSelectFx";
 import type { DraftFilterSchema } from "~/@seller-user/draft/schema/DraftFilterSchema";
 import type { DraftQuerySchema } from "~/@seller-user/draft/schema/DraftQuerySchema";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace draftFetchFx {
 	export interface Props extends DraftQuerySchema.Type {
@@ -17,11 +18,9 @@ export const draftFetchFx = Effect.fn("draftFetchFx")(function* ({
 	scope,
 	sort,
 }: draftFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"draftFetchFx.filter": filter,
-		"draftFetchFx.where": where,
-		"draftFetchFx.scope": scope,
-		"draftFetchFx.sort": sort,
+	yield* withTraceFx({
+		fx: "draftFetchFx",
+		input: { filter, where, scope, sort },
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@seller-user/draft/fx/draftPatchFx.ts
+++ b/apps/server/src/@seller-user/draft/fx/draftPatchFx.ts
@@ -4,6 +4,7 @@ import { draftFetchFx } from "~/@seller-user/draft/fx/draftFetchFx";
 import type { DraftFilterSchema } from "~/@seller-user/draft/schema/DraftFilterSchema";
 import type { DraftPatchSchema } from "~/@seller-user/draft/schema/DraftPatchSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
 
 export namespace draftPatchFx {
@@ -17,10 +18,9 @@ export const draftPatchFx = Effect.fn("draftPatchFx")(function* ({
 	query,
 	scope,
 }: draftPatchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"draftPatchFx.patch": patch,
-		"draftPatchFx.query": query,
-		"draftPatchFx.scope": scope,
+	yield* withTraceFx({
+		fx: "draftPatchFx",
+		input: { patch, query, scope },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@seller-user/draft/fx/draftResolveFx.ts
+++ b/apps/server/src/@seller-user/draft/fx/draftResolveFx.ts
@@ -1,7 +1,7 @@
 import { NotFoundErrorFx } from "@use-pico/common/error";
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
-import { AccessDeniedError } from "~/error/AccessDeniedError";
+import { AccessDeniedErrorFx } from "~/error/AccessDeniedErrorFx";
 
 export namespace draftResolveFx {
 	export interface Props {
@@ -31,7 +31,7 @@ export const draftResolveFx = Effect.fn("draftResolveFx")(function* ({
 	}
 
 	if (draft.userId !== userId) {
-		return yield* new AccessDeniedError({
+		return yield* new AccessDeniedErrorFx({
 			message,
 		});
 	}

--- a/apps/server/src/@seller-user/draft/fx/draftResolveFx.ts
+++ b/apps/server/src/@seller-user/draft/fx/draftResolveFx.ts
@@ -1,6 +1,7 @@
 import { NotFoundErrorFx } from "@use-pico/common/error";
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { AccessDeniedErrorFx } from "~/error/AccessDeniedErrorFx";
 
 export namespace draftResolveFx {
@@ -23,6 +24,14 @@ export const draftResolveFx = Effect.fn("draftResolveFx")(function* ({
 	});
 
 	if (!draft) {
+		yield* withTraceFx({
+			fx: "draftResolveFx",
+			error: {
+				resource: "draft",
+				resourceId: draftId,
+				message,
+			},
+		});
 		return yield* new NotFoundErrorFx({
 			resource: "draft",
 			resourceId: draftId,
@@ -31,6 +40,12 @@ export const draftResolveFx = Effect.fn("draftResolveFx")(function* ({
 	}
 
 	if (draft.userId !== userId) {
+		yield* withTraceFx({
+			fx: "draftResolveFx",
+			error: {
+				message,
+			},
+		});
 		return yield* new AccessDeniedErrorFx({
 			message,
 		});

--- a/apps/server/src/@seller-user/listing/create.ts
+++ b/apps/server/src/@seller-user/listing/create.ts
@@ -101,7 +101,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@seller-user/listing/fx/listingCollectionFx.ts
+++ b/apps/server/src/@seller-user/listing/fx/listingCollectionFx.ts
@@ -1,5 +1,6 @@
 import { withCollectionFx } from "@use-pico/common/collection";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withListingCollectionSelectFx } from "~/@seller-user/listing/db/withListingCollectionSelectFx";
 import { withListingQueryBuilderFx } from "~/@seller-user/listing/db/withListingQueryBuilderFx";
 import type { ListingFilterSchema } from "~/@seller-user/listing/schema/ListingFilterSchema";
@@ -18,12 +19,9 @@ export const listingCollectionFx = Effect.fn("listingCollectionFx")(function* ({
 	scope,
 	sort,
 }: listingCollectionFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingCollectionFx.cursor": cursor,
-		"listingCollectionFx.filter": filter,
-		"listingCollectionFx.where": where,
-		"listingCollectionFx.scope": scope,
-		"listingCollectionFx.sort": sort,
+	yield* withTraceFx({
+		fx: "listingCollectionFx",
+		input: { cursor, filter, where, scope, sort },
 	});
 
 	return yield* withCollectionFx({

--- a/apps/server/src/@seller-user/listing/fx/listingCountFx.ts
+++ b/apps/server/src/@seller-user/listing/fx/listingCountFx.ts
@@ -1,5 +1,6 @@
 import { withCountFx } from "@use-pico/common/count";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withListingCollectionSelectFx } from "~/@seller-user/listing/db/withListingCollectionSelectFx";
 import { withListingQueryBuilderFx } from "~/@seller-user/listing/db/withListingQueryBuilderFx";
 import type { ListingCountQuerySchema } from "~/@seller-user/listing/schema/ListingCountQuerySchema";
@@ -17,11 +18,9 @@ export const listingCountFx = Effect.fn("listingCountFx")(function* ({
 	scope,
 	count,
 }: listingCountFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingCountFx.filter": filter,
-		"listingCountFx.where": where,
-		"listingCountFx.scope": scope,
-		"listingCountFx.count": count,
+	yield* withTraceFx({
+		fx: "listingCountFx",
+		input: { filter, where, scope, count },
 	});
 
 	return yield* withCountFx({

--- a/apps/server/src/@seller-user/listing/fx/listingCreateFx.ts
+++ b/apps/server/src/@seller-user/listing/fx/listingCreateFx.ts
@@ -11,6 +11,7 @@ import { galleryItemCreateFx } from "~/@user/gallery-item/fx/galleryItemCreateFx
 import { userEventCreateFx } from "~/@user/user-event/fx/userEventCreateFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace listingCreateFx {
@@ -24,10 +25,9 @@ export const listingCreateFx = Effect.fn("listingCreateFx")(function* ({
 	uploadIds,
 	...data
 }: listingCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingCreateFx.userId": userId,
-		"listingCreateFx.uploadIds": uploadIds,
-		"listingCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "listingCreateFx",
+		input: { userId, uploadIds, ...data },
 	});
 
 	return yield* withTransactionFx(
@@ -39,6 +39,10 @@ export const listingCreateFx = Effect.fn("listingCreateFx")(function* ({
 			const now = dateContext.now();
 
 			if (uploadIds.length === 0) {
+				yield* withTraceFx({
+					fx: "listingCreateFx",
+					error: { message: "At least one upload is required" },
+				});
 				return yield* new InvalidRequestErrorFx({
 					message: "At least one upload is required",
 				});

--- a/apps/server/src/@seller-user/listing/fx/listingCreateFx.ts
+++ b/apps/server/src/@seller-user/listing/fx/listingCreateFx.ts
@@ -11,7 +11,7 @@ import { galleryItemCreateFx } from "~/@user/gallery-item/fx/galleryItemCreateFx
 import { userEventCreateFx } from "~/@user/user-event/fx/userEventCreateFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace listingCreateFx {
 	export interface Props extends ListingCreateSchema.Type {
@@ -39,7 +39,7 @@ export const listingCreateFx = Effect.fn("listingCreateFx")(function* ({
 			const now = dateContext.now();
 
 			if (uploadIds.length === 0) {
-				return yield* new InvalidRequestError({
+				return yield* new InvalidRequestErrorFx({
 					message: "At least one upload is required",
 				});
 			}

--- a/apps/server/src/@seller-user/listing/fx/listingFetchFx.ts
+++ b/apps/server/src/@seller-user/listing/fx/listingFetchFx.ts
@@ -1,5 +1,6 @@
 import { withFetchFx } from "@use-pico/common/fetch";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withListingQueryBuilderFx } from "~/@seller-user/listing/db/withListingQueryBuilderFx";
 import { withListingSelectFx } from "~/@seller-user/listing/db/withListingSelectFx";
 import type { ListingFilterSchema } from "~/@seller-user/listing/schema/ListingFilterSchema";
@@ -17,11 +18,9 @@ export const listingFetchFx = Effect.fn("listingFetchFx")(function* ({
 	scope,
 	sort,
 }: listingFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"listingFetchFx.filter": filter,
-		"listingFetchFx.where": where,
-		"listingFetchFx.scope": scope,
-		"listingFetchFx.sort": sort,
+	yield* withTraceFx({
+		fx: "listingFetchFx",
+		input: { filter, where, scope, sort },
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@seller-user/transaction-status/accept.ts
+++ b/apps/server/src/@seller-user/transaction-status/accept.ts
@@ -98,7 +98,7 @@ export const withAcceptApiFx = Effect.fn("withAcceptApiFx")(function* () {
 					AccessDeniedError() {
 						return c.json(NotFoundNotice, 404);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@seller-user/transaction-status/accept.ts
+++ b/apps/server/src/@seller-user/transaction-status/accept.ts
@@ -95,7 +95,7 @@ export const withAcceptApiFx = Effect.fn("withAcceptApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@seller-user/transaction-status/dispute.ts
+++ b/apps/server/src/@seller-user/transaction-status/dispute.ts
@@ -109,7 +109,7 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 					InvalidRequestError(e) {
 						return c.json(noticeError(e), 400);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@seller-user/transaction-status/dispute.ts
+++ b/apps/server/src/@seller-user/transaction-status/dispute.ts
@@ -103,10 +103,10 @@ export const withDisputeApiFx = Effect.fn("withDisputeApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusAcceptFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusAcceptFx.ts
@@ -5,7 +5,7 @@ import type { TransactionStatusAcceptSchema } from "~/@seller-user/transaction-s
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
-import { RuntimeError } from "~/error/RuntimeError";
+import { RuntimeErrorFx } from "~/error/RuntimeErrorFx";
 
 export namespace transactionStatusAcceptFx {
 	export interface Props extends TransactionStatusAcceptSchema.Type {
@@ -29,7 +29,7 @@ export const transactionStatusAcceptFx = Effect.fn("transactionStatusAcceptFx")(
 	});
 
 	if (transaction.side === "buyer") {
-		return yield* new RuntimeError({
+		return yield* new RuntimeErrorFx({
 			message: "Buyer cannot accept a transaction",
 		});
 	}

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusAcceptFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusAcceptFx.ts
@@ -5,6 +5,7 @@ import type { TransactionStatusAcceptSchema } from "~/@seller-user/transaction-s
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { RuntimeErrorFx } from "~/error/RuntimeErrorFx";
 
 export namespace transactionStatusAcceptFx {
@@ -17,9 +18,9 @@ export const transactionStatusAcceptFx = Effect.fn("transactionStatusAcceptFx")(
 	userId,
 	transactionId,
 }: transactionStatusAcceptFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusAcceptFx.userId": userId,
-		"transactionStatusAcceptFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionStatusAcceptFx",
+		input: { userId, transactionId },
 	});
 
 	const transaction = yield* transactionResolveFx({
@@ -29,6 +30,10 @@ export const transactionStatusAcceptFx = Effect.fn("transactionStatusAcceptFx")(
 	});
 
 	if (transaction.side === "buyer") {
+		yield* withTraceFx({
+			fx: "transactionStatusAcceptFx",
+			error: { message: "Buyer cannot accept a transaction" },
+		});
 		return yield* new RuntimeErrorFx({
 			message: "Buyer cannot accept a transaction",
 		});

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusCreateFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusCreateFx.ts
@@ -5,6 +5,7 @@ import type { TransactionStatusCreateSchema } from "~/@common/transaction-status
 import { transactionPatchFx } from "~/@seller-user/transaction/fx/transactionPatchFx";
 import { transactionStatusFetchFx } from "~/@session/transaction-status/fx/transactionStatusFetchFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionStatusCreateFx {
 	export interface Props extends TransactionStatusCreateSchema.Type {
@@ -17,9 +18,9 @@ export const transactionStatusCreateFx = Effect.fn("transactionStatusCreateFx")(
 	userId,
 	...create
 }: transactionStatusCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusCreateFx.userId": userId,
-		"transactionStatusCreateFx.create": create,
+	yield* withTraceFx({
+		fx: "transactionStatusCreateFx",
+		input: { userId, ...create },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusDisputeFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusDisputeFx.ts
@@ -4,7 +4,7 @@ import { transactionPatchFx } from "~/@seller-user/transaction/fx/transactionPat
 import { transactionStatusCreateFx } from "~/@seller-user/transaction-status/fx/transactionStatusCreateFx";
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusDisputeFx {
 	export interface Props extends TransactionStatusDisputeSchema.Type {
@@ -28,7 +28,7 @@ export const transactionStatusDisputeFx = Effect.fn("transactionStatusDisputeFx"
 	});
 
 	if (transaction.side !== "seller") {
-		return yield* new InvalidRequestError({
+		return yield* new InvalidRequestErrorFx({
 			message: "Only seller can dispute a transaction from seller-user endpoint",
 		});
 	}

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusDisputeFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusDisputeFx.ts
@@ -4,6 +4,7 @@ import { transactionPatchFx } from "~/@seller-user/transaction/fx/transactionPat
 import { transactionStatusCreateFx } from "~/@seller-user/transaction-status/fx/transactionStatusCreateFx";
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusDisputeFx {
@@ -16,9 +17,9 @@ export const transactionStatusDisputeFx = Effect.fn("transactionStatusDisputeFx"
 	userId,
 	transactionId,
 }: transactionStatusDisputeFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusDisputeFx.userId": userId,
-		"transactionStatusDisputeFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionStatusDisputeFx",
+		input: { userId, transactionId },
 	});
 
 	const transaction = yield* transactionResolveFx({
@@ -28,6 +29,12 @@ export const transactionStatusDisputeFx = Effect.fn("transactionStatusDisputeFx"
 	});
 
 	if (transaction.side !== "seller") {
+		yield* withTraceFx({
+			fx: "transactionStatusDisputeFx",
+			error: {
+				message: "Only seller can dispute a transaction from seller-user endpoint",
+			},
+		});
 		return yield* new InvalidRequestErrorFx({
 			message: "Only seller can dispute a transaction from seller-user endpoint",
 		});

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusRejectFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusRejectFx.ts
@@ -5,7 +5,7 @@ import { transactionStatusCreateFx } from "~/@seller-user/transaction-status/fx/
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusRejectFx {
 	export interface Props extends TransactionStatusRejectSchema.Type {
@@ -29,7 +29,7 @@ export const transactionStatusRejectFx = Effect.fn("transactionStatusRejectFx")(
 	});
 
 	if (transaction.side !== "seller") {
-		return yield* new InvalidRequestError({
+		return yield* new InvalidRequestErrorFx({
 			message: "Only seller can reject a transaction from seller-user endpoint",
 		});
 	}

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusRejectFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusRejectFx.ts
@@ -5,6 +5,7 @@ import { transactionStatusCreateFx } from "~/@seller-user/transaction-status/fx/
 import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCreateFx";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusRejectFx {
@@ -17,9 +18,9 @@ export const transactionStatusRejectFx = Effect.fn("transactionStatusRejectFx")(
 	userId,
 	transactionId,
 }: transactionStatusRejectFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusRejectFx.userId": userId,
-		"transactionStatusRejectFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionStatusRejectFx",
+		input: { userId, transactionId },
 	});
 
 	const transaction = yield* transactionResolveFx({
@@ -29,6 +30,12 @@ export const transactionStatusRejectFx = Effect.fn("transactionStatusRejectFx")(
 	});
 
 	if (transaction.side !== "seller") {
+		yield* withTraceFx({
+			fx: "transactionStatusRejectFx",
+			error: {
+				message: "Only seller can reject a transaction from seller-user endpoint",
+			},
+		});
 		return yield* new InvalidRequestErrorFx({
 			message: "Only seller can reject a transaction from seller-user endpoint",
 		});

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusResolveFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusResolveFx.ts
@@ -6,6 +6,7 @@ import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCr
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusResolveFx {
@@ -18,9 +19,12 @@ export const transactionStatusResolveFx = Effect.fn("transactionStatusResolveFx"
 	userId,
 	transactionId,
 }: transactionStatusResolveFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusResolveFx.userId": userId,
-		"transactionStatusResolveFx.transactionId": transactionId,
+	yield* withTraceFx({
+		fx: "transactionStatusResolveFx",
+		input: {
+			userId,
+			transactionId,
+		},
 	});
 
 	return yield* withTransactionFx(
@@ -32,6 +36,12 @@ export const transactionStatusResolveFx = Effect.fn("transactionStatusResolveFx"
 			});
 
 			if (transaction.side === "buyer") {
+				yield* withTraceFx({
+					fx: "transactionStatusResolveFx",
+					error: {
+						message: "Buyer cannot resolve a transaction",
+					},
+				});
 				return yield* new InvalidRequestErrorFx({
 					message: "Buyer cannot resolve a transaction",
 				});

--- a/apps/server/src/@seller-user/transaction-status/fx/transactionStatusResolveFx.ts
+++ b/apps/server/src/@seller-user/transaction-status/fx/transactionStatusResolveFx.ts
@@ -6,7 +6,7 @@ import { messageSystemCreateFx } from "~/@user/message-system/fx/messageSystemCr
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusResolveFx {
 	export interface Props extends TransactionStatusResolveSchema.Type {
@@ -32,7 +32,7 @@ export const transactionStatusResolveFx = Effect.fn("transactionStatusResolveFx"
 			});
 
 			if (transaction.side === "buyer") {
-				return yield* new InvalidRequestError({
+				return yield* new InvalidRequestErrorFx({
 					message: "Buyer cannot resolve a transaction",
 				});
 			}

--- a/apps/server/src/@seller-user/transaction-status/reject.ts
+++ b/apps/server/src/@seller-user/transaction-status/reject.ts
@@ -109,7 +109,7 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 					InvalidRequestError(e) {
 						return c.json(noticeError(e), 400);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@seller-user/transaction-status/reject.ts
+++ b/apps/server/src/@seller-user/transaction-status/reject.ts
@@ -103,10 +103,10 @@ export const withRejectApiFx = Effect.fn("withRejectApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@seller-user/transaction-status/resolve.ts
+++ b/apps/server/src/@seller-user/transaction-status/resolve.ts
@@ -109,7 +109,7 @@ export const withResolveApiFx = Effect.fn("withResolveApiFx")(function* () {
 					AccessDeniedError() {
 						return c.json(NotFoundNotice, 404);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@seller-user/transaction-status/resolve.ts
+++ b/apps/server/src/@seller-user/transaction-status/resolve.ts
@@ -103,10 +103,10 @@ export const withResolveApiFx = Effect.fn("withResolveApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@seller-user/transaction/fx/transactionCollectionFx.ts
+++ b/apps/server/src/@seller-user/transaction/fx/transactionCollectionFx.ts
@@ -4,6 +4,7 @@ import type { TransactionFilterSchema } from "~/@common/transaction/schema/Trans
 import type { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { withTransactionCollectionSelectFx } from "~/@seller-user/transaction/db/withTransactionCollectionSelectFx";
 import { withTransactionQueryBuilderFx } from "~/@seller-user/transaction/db/withTransactionQueryBuilderFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionCollectionFx {
 	export interface Props extends TransactionQuerySchema.Type {
@@ -18,12 +19,15 @@ export const transactionCollectionFx = Effect.fn("transactionCollectionFx")(func
 	cursor,
 	sort,
 }: transactionCollectionFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionCollectionFx.filter": filter,
-		"transactionCollectionFx.where": where,
-		"transactionCollectionFx.scope": scope,
-		"transactionCollectionFx.cursor": cursor,
-		"transactionCollectionFx.sort": sort,
+	yield* withTraceFx({
+		fx: "transactionCollectionFx",
+		input: {
+			filter,
+			where,
+			scope,
+			cursor,
+			sort,
+		},
 	});
 
 	return yield* withCollectionFx({

--- a/apps/server/src/@seller-user/transaction/fx/transactionFetchFx.ts
+++ b/apps/server/src/@seller-user/transaction/fx/transactionFetchFx.ts
@@ -4,6 +4,7 @@ import type { TransactionFilterSchema } from "~/@common/transaction/schema/Trans
 import type { TransactionQuerySchema } from "~/@common/transaction/schema/TransactionQuerySchema";
 import { withTransactionQueryBuilderFx } from "~/@seller-user/transaction/db/withTransactionQueryBuilderFx";
 import { withTransactionSelectFx } from "~/@seller-user/transaction/db/withTransactionSelectFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionFetchFx {
 	export interface Props extends TransactionQuerySchema.Type {
@@ -17,11 +18,9 @@ export const transactionFetchFx = Effect.fn("transactionFetchFx")(function* ({
 	scope,
 	sort,
 }: transactionFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionFetchFx.filter": filter,
-		"transactionFetchFx.where": where,
-		"transactionFetchFx.scope": scope,
-		"transactionFetchFx.sort": sort,
+	yield* withTraceFx({
+		fx: "transactionFetchFx",
+		input: { filter, where, scope, sort },
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@seller-user/transaction/fx/transactionPatchFx.ts
+++ b/apps/server/src/@seller-user/transaction/fx/transactionPatchFx.ts
@@ -6,6 +6,7 @@ import { transactionFetchFx } from "~/@seller-user/transaction/fx/transactionFet
 import type { TransactionPatchSchema } from "~/@seller-user/transaction/schema/TransactionPatchSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionPatchFx {
 	export interface Props extends TransactionPatchSchema.Type {
@@ -20,11 +21,9 @@ export const transactionPatchFx = Effect.fn("transactionPatchFx")(function* ({
 	query,
 	scope,
 }: transactionPatchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionPatchFx.userId": userId,
-		"transactionPatchFx.patch": patch,
-		"transactionPatchFx.query": query,
-		"transactionPatchFx.scope": scope,
+	yield* withTraceFx({
+		fx: "transactionPatchFx",
+		input: { userId, patch, query, scope },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@session/category-miss/fx/categoryMissCreateFx.ts
+++ b/apps/server/src/@session/category-miss/fx/categoryMissCreateFx.ts
@@ -3,6 +3,7 @@ import { genId } from "@use-pico/common/gen-id";
 import { Effect } from "effect";
 import { sql } from "kysely";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace categoryMissCreateFx {
 	export interface Props {
@@ -15,9 +16,9 @@ export const categoryMissCreateFx = Effect.fn("categoryMissCreateFx")(function* 
 	fulltext,
 	limit = 4,
 }: categoryMissCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"categoryMissCreateFx.fulltext": fulltext,
-		"categoryMissCreateFx.limit": limit,
+	yield* withTraceFx({
+		fx: "categoryMissCreateFx",
+		input: { fulltext, limit },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@session/category/fx/categoryCollectionFx.ts
+++ b/apps/server/src/@session/category/fx/categoryCollectionFx.ts
@@ -1,5 +1,6 @@
 import { withCollectionFx } from "@use-pico/common/collection";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withCategoryCollectionSelectFx } from "~/@session/category/db/withCategoryCollectionSelectFx";
 import { withCategoryQueryBuilderFx } from "~/@session/category/db/withCategoryQueryBuilderFx";
 import type { CategoryFilterSchema } from "~/@session/category/schema/CategoryFilterSchema";
@@ -19,12 +20,9 @@ export const categoryCollectionFx = Effect.fn("categoryCollectionFx")(function* 
 	scope,
 	sort,
 }: categoryCollectionFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"categoryCollectionFx.cursor": cursor,
-		"categoryCollectionFx.filter": filter,
-		"categoryCollectionFx.where": where,
-		"categoryCollectionFx.scope": scope,
-		"categoryCollectionFx.sort": sort,
+	yield* withTraceFx({
+		fx: "categoryCollectionFx",
+		input: { cursor, filter, where, scope, sort },
 	});
 
 	const data = yield* withCollectionFx({

--- a/apps/server/src/@session/category/fx/categoryCountFx.ts
+++ b/apps/server/src/@session/category/fx/categoryCountFx.ts
@@ -1,5 +1,6 @@
 import { withCountFx } from "@use-pico/common/count";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withCategoryCollectionSelectFx } from "~/@session/category/db/withCategoryCollectionSelectFx";
 import { withCategoryQueryBuilderFx } from "~/@session/category/db/withCategoryQueryBuilderFx";
 import type { CategoryCountQuerySchema } from "~/@session/category/schema/CategoryCountQuerySchema";
@@ -17,11 +18,9 @@ export const categoryCountFx = Effect.fn("categoryCountFx")(function* ({
 	scope,
 	count,
 }: categoryCountFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"categoryCountFx.filter": filter,
-		"categoryCountFx.where": where,
-		"categoryCountFx.scope": scope,
-		"categoryCountFx.count": count,
+	yield* withTraceFx({
+		fx: "categoryCountFx",
+		input: { filter, where, scope, count },
 	});
 
 	return yield* withCountFx({

--- a/apps/server/src/@session/category/fx/categoryFetchFx.ts
+++ b/apps/server/src/@session/category/fx/categoryFetchFx.ts
@@ -4,6 +4,7 @@ import { withCategoryQueryBuilderFx } from "~/@session/category/db/withCategoryQ
 import { withCategorySelectFx } from "~/@session/category/db/withCategorySelectFx";
 import type { CategoryFilterSchema } from "~/@session/category/schema/CategoryFilterSchema";
 import type { CategoryQuerySchema } from "~/@session/category/schema/CategoryQuerySchema";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace categoryFetchFx {
 	export interface Props extends CategoryQuerySchema.Type {
@@ -17,11 +18,9 @@ export const categoryFetchFx = Effect.fn("categoryFetchFx")(function* ({
 	scope,
 	sort,
 }: categoryFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"categoryFetchFx.filter": filter,
-		"categoryFetchFx.where": where,
-		"categoryFetchFx.scope": scope,
-		"categoryFetchFx.sort": sort,
+	yield* withTraceFx({
+		fx: "categoryFetchFx",
+		input: { filter, where, scope, sort },
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@session/location/fx/locationAutocompleteFx.ts
+++ b/apps/server/src/@session/location/fx/locationAutocompleteFx.ts
@@ -6,6 +6,7 @@ import { withLocationRequestFx } from "~/@session/location/fx/withLocationReques
 import type { LocationTableSchema } from "~/database/@table/LocationTableSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace locationAutocompleteFx {
 	export interface Props {
@@ -20,13 +21,16 @@ export const locationAutocompleteFx = Effect.fn("locationAutocompleteFx")(functi
 	lang,
 	limit = 5,
 }: locationAutocompleteFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"locationAutocompleteFx.text": text,
-		"locationAutocompleteFx.lang": lang,
-		"locationAutocompleteFx.limit": limit,
+	yield* withTraceFx({
+		fx: "locationAutocompleteFx",
+		input: { text, lang, limit },
 	});
 
 	if (text.length < 3) {
+		yield* withTraceFx({
+			fx: "locationAutocompleteFx",
+			error: { message: "Text too short" },
+		});
 		return yield* new TextTooShortErrorFx({
 			message: "Text too short",
 		});

--- a/apps/server/src/@session/location/fx/locationFetchFx.ts
+++ b/apps/server/src/@session/location/fx/locationFetchFx.ts
@@ -1,5 +1,6 @@
 import { withFetchFx } from "@use-pico/common/fetch";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withLocationQueryBuilderFx } from "~/@session/location/db/withLocationQueryBuilderFx";
 import { withLocationSelectFx } from "~/@session/location/db/withLocationSelectFx";
 import type { LocationQuerySchema } from "~/@session/location/schema/LocationQuerySchema";
@@ -13,10 +14,9 @@ export const locationFetchFx = Effect.fn("locationFetchFx")(function* ({
 	where,
 	sort,
 }: locationFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"locationFetchFx.filter": filter,
-		"locationFetchFx.where": where,
-		"locationFetchFx.sort": sort,
+	yield* withTraceFx({
+		fx: "locationFetchFx",
+		input: { filter, where, sort },
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@session/transaction-status/fx/transactionStatusFetchFx.ts
+++ b/apps/server/src/@session/transaction-status/fx/transactionStatusFetchFx.ts
@@ -1,5 +1,6 @@
 import { withFetchFx } from "@use-pico/common/fetch";
 import { Effect } from "effect";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withTransactionStatusQueryBuilderFx } from "~/@session/transaction-status/db/withTransactionStatusQueryBuilderFx";
 import { withTransactionStatusSelectFx } from "~/@session/transaction-status/db/withTransactionStatusSelectFx";
 import type { TransactionStatusFilterSchema } from "~/@session/transaction-status/schema/TransactionStatusFilterSchema";
@@ -17,11 +18,9 @@ export const transactionStatusFetchFx = Effect.fn("transactionStatusFetchFx")(fu
 	scope,
 	sort,
 }: transactionStatusFetchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusFetchFx.filter": filter,
-		"transactionStatusFetchFx.where": where,
-		"transactionStatusFetchFx.scope": scope,
-		"transactionStatusFetchFx.sort": sort,
+	yield* withTraceFx({
+		fx: "transactionStatusFetchFx",
+		input: { filter, where, scope, sort },
 	});
 
 	return yield* withFetchFx({

--- a/apps/server/src/@user/gallery-item/fx/galleryItemCreateFx.ts
+++ b/apps/server/src/@user/gallery-item/fx/galleryItemCreateFx.ts
@@ -5,6 +5,7 @@ import { galleryFetchFx } from "~/@user/gallery/fx/galleryFetchFx";
 import { galleryItemFetchFx } from "~/@user/gallery-item/fx/galleryItemFetchFx";
 import type { GalleryItemCreateSchema } from "~/@user/gallery-item/schema/GalleryItemCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace galleryItemCreateFx {
 	export interface Props extends GalleryItemCreateSchema.Type {
@@ -17,10 +18,9 @@ export const galleryItemCreateFx = Effect.fn("galleryItemCreateFx")(function* ({
 	galleryId,
 	...data
 }: galleryItemCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"galleryItemCreateFx.userId": userId,
-		"galleryItemCreateFx.galleryId": galleryId,
-		"galleryItemCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "galleryItemCreateFx",
+		input: { userId, galleryId, ...data },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@user/gallery/fx/galleryCreateFx.ts
+++ b/apps/server/src/@user/gallery/fx/galleryCreateFx.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect";
 import { galleryFetchFx } from "~/@user/gallery/fx/galleryFetchFx";
 import type { GalleryCreateSchema } from "~/@user/gallery/schema/GalleryCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace galleryCreateFx {
 	export interface Props extends GalleryCreateSchema.Type {
@@ -17,10 +18,9 @@ export const galleryCreateFx = Effect.fn("galleryCreateFx")(function* ({
 	id,
 	...props
 }: galleryCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"galleryCreateFx.userId": userId,
-		"galleryCreateFx.id": id,
-		"galleryCreateFx.props": props,
+	yield* withTraceFx({
+		fx: "galleryCreateFx",
+		input: { userId, id, ...props },
 	});
 
 	const { kysely } = yield* KyselyContextFx;

--- a/apps/server/src/@user/message-gallery/fx/messageGalleryCreateFx.ts
+++ b/apps/server/src/@user/message-gallery/fx/messageGalleryCreateFx.ts
@@ -5,6 +5,7 @@ import { messageGalleryFetchFx } from "~/@user/message-gallery/fx/messageGallery
 import type { MessageGalleryCreateSchema } from "~/@user/message-gallery/schema/MessageGalleryCreateSchema";
 import { messageUserCheckFx } from "~/@user/message-thread-user/fx/messageUserCheckFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
 
 export namespace messageGalleryCreateFx {
@@ -18,10 +19,9 @@ export const messageGalleryCreateFx = Effect.fn("messageGalleryCreateFx")(functi
 	messageThreadId,
 	galleryId,
 }: messageGalleryCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"messageGalleryCreateFx.userId": userId,
-		"messageGalleryCreateFx.messageThreadId": messageThreadId,
-		"messageGalleryCreateFx.galleryId": galleryId,
+	yield* withTraceFx({
+		fx: "messageGalleryCreateFx",
+		input: { userId, messageThreadId, galleryId },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-location/fx/messageLocationCreateFx.ts
+++ b/apps/server/src/@user/message-location/fx/messageLocationCreateFx.ts
@@ -21,7 +21,11 @@ export const messageLocationCreateFx = Effect.fn("messageLocationCreateFx")(func
 }: messageLocationCreateFx.Props) {
 	yield* withTraceFx({
 		fx: "messageLocationCreateFx",
-		input: { userId, messageThreadId, locationId },
+		input: {
+			userId,
+			messageThreadId,
+			locationId: "(redacted)",
+		},
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-location/fx/messageLocationCreateFx.ts
+++ b/apps/server/src/@user/message-location/fx/messageLocationCreateFx.ts
@@ -6,6 +6,7 @@ import type { MessageLocationCreateSchema } from "~/@user/message-location/schem
 import { messageUserCheckFx } from "~/@user/message-thread-user/fx/messageUserCheckFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace messageLocationCreateFx {
 	export interface Props extends MessageLocationCreateSchema.Type {
@@ -18,10 +19,9 @@ export const messageLocationCreateFx = Effect.fn("messageLocationCreateFx")(func
 	messageThreadId,
 	locationId,
 }: messageLocationCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"messageLocationCreateFx.userId": userId,
-		"messageLocationCreateFx.messageThreadId": messageThreadId,
-		"messageLocationCreateFx.locationId": "(redacted)",
+	yield* withTraceFx({
+		fx: "messageLocationCreateFx",
+		input: { userId, messageThreadId, locationId },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-package/fx/messagePackageCreateFx.ts
+++ b/apps/server/src/@user/message-package/fx/messagePackageCreateFx.ts
@@ -21,7 +21,11 @@ export const messagePackageCreateFx = Effect.fn("messagePackageCreateFx")(functi
 }: messagePackageCreateFx.Props) {
 	yield* withTraceFx({
 		fx: "messagePackageCreateFx",
-		input: { userId, messageThreadId, ...data },
+		input: {
+			userId,
+			messageThreadId,
+			data: "(redacted)",
+		},
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-package/fx/messagePackageCreateFx.ts
+++ b/apps/server/src/@user/message-package/fx/messagePackageCreateFx.ts
@@ -6,6 +6,7 @@ import type { MessagePackageCreateSchema } from "~/@user/message-package/schema/
 import { messageUserCheckFx } from "~/@user/message-thread-user/fx/messageUserCheckFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace messagePackageCreateFx {
 	export interface Props extends MessagePackageCreateSchema.Type {
@@ -18,10 +19,9 @@ export const messagePackageCreateFx = Effect.fn("messagePackageCreateFx")(functi
 	messageThreadId,
 	...data
 }: messagePackageCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"messagePackageCreateFx.userId": userId,
-		"messagePackageCreateFx.messageThreadId": messageThreadId,
-		"messagePackageCreateFx.data": "(redacted)",
+	yield* withTraceFx({
+		fx: "messagePackageCreateFx",
+		input: { userId, messageThreadId, ...data },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-personal/fx/messagePersonalCreateFx.ts
+++ b/apps/server/src/@user/message-personal/fx/messagePersonalCreateFx.ts
@@ -6,6 +6,7 @@ import type { MessagePersonalCreateSchema } from "~/@user/message-personal/schem
 import { messageUserCheckFx } from "~/@user/message-thread-user/fx/messageUserCheckFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace messagePersonalCreateFx {
 	export interface Props extends MessagePersonalCreateSchema.Type {
@@ -18,10 +19,9 @@ export const messagePersonalCreateFx = Effect.fn("messagePersonalCreateFx")(func
 	messageThreadId,
 	...data
 }: messagePersonalCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"messagePersonalCreateFx.userId": userId,
-		"messagePersonalCreateFx.messageThreadId": messageThreadId,
-		"messagePersonalCreateFx.data": "(redacted)",
+	yield* withTraceFx({
+		fx: "messagePersonalCreateFx",
+		input: { userId, messageThreadId, ...data },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-personal/fx/messagePersonalCreateFx.ts
+++ b/apps/server/src/@user/message-personal/fx/messagePersonalCreateFx.ts
@@ -21,7 +21,11 @@ export const messagePersonalCreateFx = Effect.fn("messagePersonalCreateFx")(func
 }: messagePersonalCreateFx.Props) {
 	yield* withTraceFx({
 		fx: "messagePersonalCreateFx",
-		input: { userId, messageThreadId, ...data },
+		input: {
+			userId,
+			messageThreadId,
+			data: "(redacted)",
+		},
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-system/fx/messageSystemCreateFx.ts
+++ b/apps/server/src/@user/message-system/fx/messageSystemCreateFx.ts
@@ -5,6 +5,7 @@ import { messageSystemFetchFx } from "~/@user/message-system/fx/messageSystemFet
 import type { MessageSystemCreateSchema } from "~/@user/message-system/schema/MessageSystemCreateSchema";
 import { messageUserCheckFx } from "~/@user/message-thread-user/fx/messageUserCheckFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
 
 export namespace messageSystemCreateFx {
@@ -18,10 +19,9 @@ export const messageSystemCreateFx = Effect.fn("messageSystemCreateFx")(function
 	messageThreadId,
 	...data
 }: messageSystemCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"messageSystemCreateFx.userId": userId,
-		"messageSystemCreateFx.messageThreadId": messageThreadId,
-		"messageSystemCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "messageSystemCreateFx",
+		input: { userId, messageThreadId, ...data },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-text/fx/messageTextCreateFx.ts
+++ b/apps/server/src/@user/message-text/fx/messageTextCreateFx.ts
@@ -21,7 +21,11 @@ export const messageTextCreateFx = Effect.fn("messageTextCreateFx")(function* ({
 }: messageTextCreateFx.Props) {
 	yield* withTraceFx({
 		fx: "messageTextCreateFx",
-		input: { userId, messageThreadId, message },
+		input: {
+			userId,
+			messageThreadId,
+			message: "(redacted)",
+		},
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-text/fx/messageTextCreateFx.ts
+++ b/apps/server/src/@user/message-text/fx/messageTextCreateFx.ts
@@ -6,6 +6,7 @@ import type { MessageTextCreateSchema } from "~/@user/message-text/schema/Messag
 import { messageUserCheckFx } from "~/@user/message-thread-user/fx/messageUserCheckFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace messageTextCreateFx {
 	export interface Props extends MessageTextCreateSchema.Type {
@@ -18,10 +19,9 @@ export const messageTextCreateFx = Effect.fn("messageTextCreateFx")(function* ({
 	messageThreadId,
 	message,
 }: messageTextCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"messageTextCreateFx.userId": userId,
-		"messageTextCreateFx.messageThreadId": messageThreadId,
-		"messageTextCreateFx.message": "(redacted)",
+	yield* withTraceFx({
+		fx: "messageTextCreateFx",
+		input: { userId, messageThreadId, message },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-thread-user/fx/messageUserCheckFx.ts
+++ b/apps/server/src/@user/message-thread-user/fx/messageUserCheckFx.ts
@@ -1,6 +1,7 @@
 import { NotFoundErrorFx } from "@use-pico/common/error";
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace messageUserCheckFx {
 	export interface Props {
@@ -26,6 +27,14 @@ export const messageUserCheckFx = Effect.fn("messageUserCheckFx")(function* ({
 	});
 
 	if (!result) {
+		yield* withTraceFx({
+			fx: "messageUserCheckFx",
+			error: {
+				resource: "message-thread-user",
+				resourceId: "(user-ids+messageThreadId)",
+				message: "User is not in the related thread",
+			},
+		});
 		return yield* new NotFoundErrorFx({
 			resource: "message-thread-user",
 			resourceId: "(user-ids+messageThreadId)",

--- a/apps/server/src/@user/message-thread/fx/messageThreadCreateFx.ts
+++ b/apps/server/src/@user/message-thread/fx/messageThreadCreateFx.ts
@@ -5,6 +5,7 @@ import { messageThreadFetchFx } from "~/@user/message-thread/fx/messageThreadFet
 import type { MessageThreadCreateSchema } from "~/@user/message-thread/schema/MessageThreadCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace messageThreadCreateFx {
 	export type Props = MessageThreadCreateSchema.Type;
@@ -13,8 +14,9 @@ export namespace messageThreadCreateFx {
 export const messageThreadCreateFx = Effect.fn("messageThreadCreateFx")(function* (
 	props: messageThreadCreateFx.Props,
 ) {
-	yield* Effect.annotateLogsScoped({
-		"messageThreadCreateFx.props": props,
+	yield* withTraceFx({
+		fx: "messageThreadCreateFx",
+		input: props,
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/message-thread/fx/messageThreadPatchFx.ts
+++ b/apps/server/src/@user/message-thread/fx/messageThreadPatchFx.ts
@@ -6,6 +6,7 @@ import type { MessageThreadPatchSchema } from "~/@user/message-thread/schema/Mes
 import { messageUserCheckFx } from "~/@user/message-thread-user/fx/messageUserCheckFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace messageThreadPatchFx {
 	export interface Props extends MessageThreadPatchSchema.Type {
@@ -20,11 +21,9 @@ export const messageThreadPatchFx = Effect.fn("messageThreadPatchFx")(function* 
 	query,
 	scope,
 }: messageThreadPatchFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"messageThreadPatchFx.userId": userId,
-		"messageThreadPatchFx.patch": patch,
-		"messageThreadPatchFx.query": query,
-		"messageThreadPatchFx.scope": scope,
+	yield* withTraceFx({
+		fx: "messageThreadPatchFx",
+		input: { userId, patch, query, scope },
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-message-gallery/create.ts
+++ b/apps/server/src/@user/transaction-message-gallery/create.ts
@@ -110,7 +110,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					AccessDeniedError() {
 						return c.json(NotFoundNotice, 404);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@user/transaction-message-gallery/create.ts
+++ b/apps/server/src/@user/transaction-message-gallery/create.ts
@@ -101,13 +101,13 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				withDateFx,
 				withTransactionContextFx(),
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@user/transaction-message-gallery/fx/transactionMessageGalleryCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-gallery/fx/transactionMessageGalleryCreateFx.ts
@@ -9,7 +9,7 @@ import { transactionStatusGateFx } from "~/@user/transaction-status/fx/transacti
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionMessageGalleryCreateFx {
 	export interface Props extends TransactionMessageGalleryCreateSchema.Type {
@@ -32,7 +32,7 @@ export const transactionMessageGalleryCreateFx = Effect.fn("transactionMessageGa
 				const dateContext = yield* DateContextFx;
 
 				if (uploadIds.length === 0) {
-					return yield* new InvalidRequestError({
+					return yield* new InvalidRequestErrorFx({
 						message: "At least one upload is required",
 					});
 				}

--- a/apps/server/src/@user/transaction-message-gallery/fx/transactionMessageGalleryCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-gallery/fx/transactionMessageGalleryCreateFx.ts
@@ -9,6 +9,7 @@ import { transactionStatusGateFx } from "~/@user/transaction-status/fx/transacti
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionMessageGalleryCreateFx {
@@ -19,10 +20,13 @@ export namespace transactionMessageGalleryCreateFx {
 
 export const transactionMessageGalleryCreateFx = Effect.fn("transactionMessageGalleryCreateFx")(
 	function* ({ userId, transactionId, uploadIds }: transactionMessageGalleryCreateFx.Props) {
-		yield* Effect.annotateLogsScoped({
-			"transactionMessageGalleryCreateFx.userId": userId,
-			"transactionMessageGalleryCreateFx.transactionId": transactionId,
-			"transactionMessageGalleryCreateFx.uploadIds": uploadIds,
+		yield* withTraceFx({
+			fx: "transactionMessageGalleryCreateFx",
+			input: {
+				userId,
+				transactionId,
+				uploadIds,
+			},
 		});
 
 		return yield* withTransactionFx(
@@ -32,6 +36,12 @@ export const transactionMessageGalleryCreateFx = Effect.fn("transactionMessageGa
 				const dateContext = yield* DateContextFx;
 
 				if (uploadIds.length === 0) {
+					yield* withTraceFx({
+						fx: "transactionMessageGalleryCreateFx",
+						error: {
+							message: "At least one upload is required",
+						},
+					});
 					return yield* new InvalidRequestErrorFx({
 						message: "At least one upload is required",
 					});

--- a/apps/server/src/@user/transaction-message-location/create.ts
+++ b/apps/server/src/@user/transaction-message-location/create.ts
@@ -110,7 +110,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					AccessDeniedError() {
 						return c.json(NotFoundNotice, 404);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@user/transaction-message-location/create.ts
+++ b/apps/server/src/@user/transaction-message-location/create.ts
@@ -101,13 +101,13 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				withDateFx,
 				withTransactionContextFx(),
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@user/transaction-message-location/fx/transactionMessageLocationCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-location/fx/transactionMessageLocationCreateFx.ts
@@ -7,6 +7,7 @@ import { transactionStatusGateFx } from "~/@user/transaction-status/fx/transacti
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionMessageLocationCreateFx {
 	export interface Props extends TransactionMessageLocationCreateSchema.Type {
@@ -16,10 +17,9 @@ export namespace transactionMessageLocationCreateFx {
 
 export const transactionMessageLocationCreateFx = Effect.fn("transactionMessageLocationCreateFx")(
 	function* ({ userId, transactionId, locationId }: transactionMessageLocationCreateFx.Props) {
-		yield* Effect.annotateLogsScoped({
-			"transactionMessageLocationCreateFx.userId": userId,
-			"transactionMessageLocationCreateFx.transactionId": transactionId,
-			"transactionMessageLocationCreateFx.locationId": "(redacted)",
+		yield* withTraceFx({
+			fx: "transactionMessageLocationCreateFx",
+			input: { userId, transactionId, locationId },
 		});
 
 		return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-message-location/fx/transactionMessageLocationCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-location/fx/transactionMessageLocationCreateFx.ts
@@ -19,7 +19,11 @@ export const transactionMessageLocationCreateFx = Effect.fn("transactionMessageL
 	function* ({ userId, transactionId, locationId }: transactionMessageLocationCreateFx.Props) {
 		yield* withTraceFx({
 			fx: "transactionMessageLocationCreateFx",
-			input: { userId, transactionId, locationId },
+			input: {
+				userId,
+				transactionId,
+				locationId: "(redacted)",
+			},
 		});
 
 		return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-message-package/create.ts
+++ b/apps/server/src/@user/transaction-message-package/create.ts
@@ -110,7 +110,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					AccessDeniedError() {
 						return c.json(NotFoundNotice, 404);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@user/transaction-message-package/create.ts
+++ b/apps/server/src/@user/transaction-message-package/create.ts
@@ -101,13 +101,13 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				withDateFx,
 				withTransactionContextFx(),
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@user/transaction-message-package/fx/transactionMessagePackageCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-package/fx/transactionMessagePackageCreateFx.ts
@@ -19,7 +19,11 @@ export const transactionMessagePackageCreateFx = Effect.fn("transactionMessagePa
 	function* ({ userId, transactionId, ...data }: transactionMessagePackageCreateFx.Props) {
 		yield* withTraceFx({
 			fx: "transactionMessagePackageCreateFx",
-			input: { userId, transactionId, ...data },
+			input: {
+				userId,
+				transactionId,
+				data: "(redacted)",
+			},
 		});
 
 		return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-message-package/fx/transactionMessagePackageCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-package/fx/transactionMessagePackageCreateFx.ts
@@ -7,6 +7,7 @@ import { transactionStatusGateFx } from "~/@user/transaction-status/fx/transacti
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionMessagePackageCreateFx {
 	export interface Props extends TransactionMessagePackageCreateSchema.Type {
@@ -16,10 +17,9 @@ export namespace transactionMessagePackageCreateFx {
 
 export const transactionMessagePackageCreateFx = Effect.fn("transactionMessagePackageCreateFx")(
 	function* ({ userId, transactionId, ...data }: transactionMessagePackageCreateFx.Props) {
-		yield* Effect.annotateLogsScoped({
-			"transactionMessagePackageCreateFx.userId": userId,
-			"transactionMessagePackageCreateFx.transactionId": transactionId,
-			"transactionMessagePackageCreateFx.data": "(redacted)",
+		yield* withTraceFx({
+			fx: "transactionMessagePackageCreateFx",
+			input: { userId, transactionId, ...data },
 		});
 
 		return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-message-personal/create.ts
+++ b/apps/server/src/@user/transaction-message-personal/create.ts
@@ -108,10 +108,10 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@user/transaction-message-personal/create.ts
+++ b/apps/server/src/@user/transaction-message-personal/create.ts
@@ -105,7 +105,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					InvalidRequestError(e) {

--- a/apps/server/src/@user/transaction-message-personal/fx/transactionMessagePersonalCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-personal/fx/transactionMessagePersonalCreateFx.ts
@@ -19,7 +19,11 @@ export const transactionMessagePersonalCreateFx = Effect.fn("transactionMessageP
 	function* ({ userId, transactionId, ...data }: transactionMessagePersonalCreateFx.Props) {
 		yield* withTraceFx({
 			fx: "transactionMessagePersonalCreateFx",
-			input: { userId, transactionId, ...data },
+			input: {
+				userId,
+				transactionId,
+				data: "(redacted)",
+			},
 		});
 
 		return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-message-personal/fx/transactionMessagePersonalCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-personal/fx/transactionMessagePersonalCreateFx.ts
@@ -7,6 +7,7 @@ import { transactionStatusGateFx } from "~/@user/transaction-status/fx/transacti
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionMessagePersonalCreateFx {
 	export interface Props extends TransactionMessagePersonalCreateSchema.Type {
@@ -16,10 +17,9 @@ export namespace transactionMessagePersonalCreateFx {
 
 export const transactionMessagePersonalCreateFx = Effect.fn("transactionMessagePersonalCreateFx")(
 	function* ({ userId, transactionId, ...data }: transactionMessagePersonalCreateFx.Props) {
-		yield* Effect.annotateLogsScoped({
-			"transactionMessagePersonalCreateFx.userId": userId,
-			"transactionMessagePersonalCreateFx.transactionId": transactionId,
-			"transactionMessagePersonalCreateFx.data": "(redacted)",
+		yield* withTraceFx({
+			fx: "transactionMessagePersonalCreateFx",
+			input: { userId, transactionId, ...data },
 		});
 
 		return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-message-text/create.ts
+++ b/apps/server/src/@user/transaction-message-text/create.ts
@@ -110,7 +110,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 					AccessDeniedError() {
 						return c.json(NotFoundNotice, 404);
 					},
-					RuntimeError(e) {
+					RuntimeErrorFx(e) {
 						return c.json(noticeError(e), 500);
 					},
 					ZodErrorFx({ zod }) {

--- a/apps/server/src/@user/transaction-message-text/create.ts
+++ b/apps/server/src/@user/transaction-message-text/create.ts
@@ -101,13 +101,13 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				withDateFx,
 				withTransactionContextFx(),
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
-					AccessDeniedError() {
+					AccessDeniedErrorFx() {
 						return c.json(NotFoundNotice, 404);
 					},
 					RuntimeErrorFx(e) {

--- a/apps/server/src/@user/transaction-message-text/fx/transactionMessageTextCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-text/fx/transactionMessageTextCreateFx.ts
@@ -19,7 +19,11 @@ export const transactionMessageTextCreateFx = Effect.fn("transactionMessageTextC
 	function* ({ userId, transactionId, message }: transactionMessageTextCreateFx.Props) {
 		yield* withTraceFx({
 			fx: "transactionMessageTextCreateFx",
-			input: { userId, transactionId, message },
+			input: {
+				userId,
+				transactionId,
+				message: "(redacted)",
+			},
 		});
 
 		return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-message-text/fx/transactionMessageTextCreateFx.ts
+++ b/apps/server/src/@user/transaction-message-text/fx/transactionMessageTextCreateFx.ts
@@ -7,6 +7,7 @@ import { transactionStatusGateFx } from "~/@user/transaction-status/fx/transacti
 import { userInteractionEventFx } from "~/@user/user-event/fx/userInteractionEventFx";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 export namespace transactionMessageTextCreateFx {
 	export interface Props extends TransactionMessageTextCreateSchema.Type {
@@ -16,10 +17,9 @@ export namespace transactionMessageTextCreateFx {
 
 export const transactionMessageTextCreateFx = Effect.fn("transactionMessageTextCreateFx")(
 	function* ({ userId, transactionId, message }: transactionMessageTextCreateFx.Props) {
-		yield* Effect.annotateLogsScoped({
-			"transactionMessageTextCreateFx.userId": userId,
-			"transactionMessageTextCreateFx.transactionId": transactionId,
-			"transactionMessageTextCreateFx.message": "(redacted)",
+		yield* withTraceFx({
+			fx: "transactionMessageTextCreateFx",
+			input: { userId, transactionId, message },
 		});
 
 		return yield* withTransactionFx(

--- a/apps/server/src/@user/transaction-status/fx/transactionStatusGateFx.ts
+++ b/apps/server/src/@user/transaction-status/fx/transactionStatusGateFx.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import type { TransactionStatusEnumSchema } from "~/database/@enum/TransactionStatusEnumSchema";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusGateFx {
 	export interface Props {
@@ -31,7 +31,7 @@ export const transactionStatusGateFx = Effect.fn("transactionStatusGateFx")(func
 	});
 
 	if (!transaction.status || !allowedStatuses.includes(transaction.status)) {
-		return yield* new InvalidRequestError({
+		return yield* new InvalidRequestErrorFx({
 			message:
 				message ??
 				`Transaction must be in one of the following statuses: ${allowedStatuses.join(", ")}`,

--- a/apps/server/src/@user/transaction-status/fx/transactionStatusGateFx.ts
+++ b/apps/server/src/@user/transaction-status/fx/transactionStatusGateFx.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { transactionResolveFx } from "~/@user/transaction/fx/transactionResolveFx";
 import type { TransactionStatusEnumSchema } from "~/database/@enum/TransactionStatusEnumSchema";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace transactionStatusGateFx {
@@ -18,11 +19,14 @@ export const transactionStatusGateFx = Effect.fn("transactionStatusGateFx")(func
 	allowedStatuses,
 	message,
 }: transactionStatusGateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionStatusGateFx.userId": userId,
-		"transactionStatusGateFx.transactionId": transactionId,
-		"transactionStatusGateFx.allowedStatuses": allowedStatuses,
-		"transactionStatusGateFx.message": message,
+	yield* withTraceFx({
+		fx: "transactionStatusGateFx",
+		input: {
+			userId,
+			transactionId,
+			allowedStatuses,
+			message,
+		},
 	});
 
 	const transaction = yield* transactionResolveFx({
@@ -31,10 +35,17 @@ export const transactionStatusGateFx = Effect.fn("transactionStatusGateFx")(func
 	});
 
 	if (!transaction.status || !allowedStatuses.includes(transaction.status)) {
+		const errorMessage =
+			message ??
+			`Transaction must be in one of the following statuses: ${allowedStatuses.join(", ")}`;
+		yield* withTraceFx({
+			fx: "transactionStatusGateFx",
+			error: {
+				message: errorMessage,
+			},
+		});
 		return yield* new InvalidRequestErrorFx({
-			message:
-				message ??
-				`Transaction must be in one of the following statuses: ${allowedStatuses.join(", ")}`,
+			message: errorMessage,
 		});
 	}
 

--- a/apps/server/src/@user/transaction/fx/transactionResolveFx.ts
+++ b/apps/server/src/@user/transaction/fx/transactionResolveFx.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
-import { AccessDeniedError } from "~/error/AccessDeniedError";
+import { AccessDeniedErrorFx } from "~/error/AccessDeniedErrorFx";
 import { RuntimeErrorFx } from "~/error/RuntimeErrorFx";
 
 export namespace transactionResolveFx {
@@ -63,7 +63,7 @@ export const transactionResolveFx = Effect.fn("transactionResolveFx")(function* 
 	});
 
 	if (!transaction) {
-		return yield* new AccessDeniedError({
+		return yield* new AccessDeniedErrorFx({
 			message,
 		});
 	}

--- a/apps/server/src/@user/transaction/fx/transactionResolveFx.ts
+++ b/apps/server/src/@user/transaction/fx/transactionResolveFx.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { AccessDeniedError } from "~/error/AccessDeniedError";
-import { RuntimeError } from "~/error/RuntimeError";
+import { RuntimeErrorFx } from "~/error/RuntimeErrorFx";
 
 export namespace transactionResolveFx {
 	export interface Props {
@@ -69,7 +69,7 @@ export const transactionResolveFx = Effect.fn("transactionResolveFx")(function* 
 	}
 
 	if (!transaction.status) {
-		return yield* new RuntimeError({
+		return yield* new RuntimeErrorFx({
 			message: "Transaction status is missing",
 		});
 	}

--- a/apps/server/src/@user/transaction/fx/transactionResolveFx.ts
+++ b/apps/server/src/@user/transaction/fx/transactionResolveFx.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { AccessDeniedErrorFx } from "~/error/AccessDeniedErrorFx";
 import { RuntimeErrorFx } from "~/error/RuntimeErrorFx";
 
@@ -16,10 +17,9 @@ export const transactionResolveFx = Effect.fn("transactionResolveFx")(function* 
 	transactionId,
 	message = "You are not allowed to access this transaction",
 }: transactionResolveFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"transactionResolveFx.userId": userId,
-		"transactionResolveFx.transactionId": transactionId,
-		"transactionResolveFx.message": message,
+	yield* withTraceFx({
+		fx: "transactionResolveFx",
+		input: { userId, transactionId, message },
 	});
 
 	const { kysely } = yield* KyselyContextFx;
@@ -63,12 +63,20 @@ export const transactionResolveFx = Effect.fn("transactionResolveFx")(function* 
 	});
 
 	if (!transaction) {
+		yield* withTraceFx({
+			fx: "transactionResolveFx",
+			error: { message },
+		});
 		return yield* new AccessDeniedErrorFx({
 			message,
 		});
 	}
 
 	if (!transaction.status) {
+		yield* withTraceFx({
+			fx: "transactionResolveFx",
+			error: { message: "Transaction status is missing" },
+		});
 		return yield* new RuntimeErrorFx({
 			message: "Transaction status is missing",
 		});

--- a/apps/server/src/@user/upload/create.ts
+++ b/apps/server/src/@user/upload/create.ts
@@ -104,7 +104,7 @@ export const withCreateApiFx = Effect.fn("withCreateApiFx")(function* () {
 				}),
 				withLoggingFx(axiomConfig, "apiUploadCreate"),
 				withCatchFx({
-					InvalidRequestError(e) {
+					InvalidRequestErrorFx(e) {
 						return c.json(noticeError(e), 400);
 					},
 					NotFoundErrorFx() {

--- a/apps/server/src/@user/upload/fx/uploadCreateFx.ts
+++ b/apps/server/src/@user/upload/fx/uploadCreateFx.ts
@@ -5,7 +5,7 @@ import { UploadContextFx } from "~/@common/upload/context/UploadContextFx";
 import { uploadFetchFx } from "~/@user/upload/fx/uploadFetchFx";
 import type { UploadCreateSchema } from "~/@user/upload/schema/UploadCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
-import { InvalidRequestError } from "~/error/InvalidRequestError";
+import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace uploadCreateFx {
 	export interface Props extends UploadCreateSchema.Type {
@@ -29,7 +29,7 @@ export const uploadCreateFx = Effect.fn("uploadCreateFx")(function* ({
 	const dateContext = yield* DateContextFx;
 
 	if (!url.startsWith(uploadContext.cdn)) {
-		return yield* new InvalidRequestError({
+		return yield* new InvalidRequestErrorFx({
 			message: "Only content from the CDN can be uploaded",
 		});
 	}

--- a/apps/server/src/@user/upload/fx/uploadCreateFx.ts
+++ b/apps/server/src/@user/upload/fx/uploadCreateFx.ts
@@ -5,6 +5,7 @@ import { UploadContextFx } from "~/@common/upload/context/UploadContextFx";
 import { uploadFetchFx } from "~/@user/upload/fx/uploadFetchFx";
 import type { UploadCreateSchema } from "~/@user/upload/schema/UploadCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 import { InvalidRequestErrorFx } from "~/error/InvalidRequestErrorFx";
 
 export namespace uploadCreateFx {
@@ -18,10 +19,13 @@ export const uploadCreateFx = Effect.fn("uploadCreateFx")(function* ({
 	url,
 	...data
 }: uploadCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"uploadCreateFx.userId": userId,
-		"uploadCreateFx.url": url,
-		"uploadCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "uploadCreateFx",
+		input: {
+			userId,
+			url,
+			...data,
+		},
 	});
 
 	const { kysely } = yield* KyselyContextFx;
@@ -29,6 +33,12 @@ export const uploadCreateFx = Effect.fn("uploadCreateFx")(function* ({
 	const dateContext = yield* DateContextFx;
 
 	if (!url.startsWith(uploadContext.cdn)) {
+		yield* withTraceFx({
+			fx: "uploadCreateFx",
+			error: {
+				message: "Only content from the CDN can be uploaded",
+			},
+		});
 		return yield* new InvalidRequestErrorFx({
 			message: "Only content from the CDN can be uploaded",
 		});

--- a/apps/server/src/@user/user-event/fx/userEventCreateFx.ts
+++ b/apps/server/src/@user/user-event/fx/userEventCreateFx.ts
@@ -6,6 +6,7 @@ import type { UserEventEnumSchema } from "~/@common/user-event/schema/UserEventE
 import type { UserEventCreateSchema } from "~/@user/user-event/schema/UserEventCreateSchema";
 import { KyselyContextFx } from "~/database/context/KyselyContextFx";
 import { withTransactionFx } from "~/database/fx/withTransactionFx";
+import { withTraceFx } from "~/effect/withTraceFx";
 
 const ignored: UserEventEnumSchema.Type[] = [
 	"listing.create",
@@ -22,10 +23,13 @@ export const userEventCreateFx = Effect.fn("userEventCreateFx")(function* ({
 	group,
 	...data
 }: userEventCreateFx.Props) {
-	yield* Effect.annotateLogsScoped({
-		"userEventCreateFx.userId": userId,
-		"userEventCreateFx.group": group,
-		"userEventCreateFx.data": data,
+	yield* withTraceFx({
+		fx: "userEventCreateFx",
+		input: {
+			userId,
+			group,
+			...data,
+		},
 	});
 
 	return yield* withTransactionFx(

--- a/apps/server/src/effect/withTraceFx.ts
+++ b/apps/server/src/effect/withTraceFx.ts
@@ -1,0 +1,15 @@
+import { Effect, HashMap, Option } from "effect";
+
+export const withTraceFx = (item: unknown) =>
+	Effect.gen(function* () {
+		const annotations = yield* Effect.logAnnotations;
+
+		const prev = HashMap.get(annotations, "$trace").pipe(
+			Option.getOrElse(() => []),
+		) as unknown[];
+
+		yield* Effect.annotateLogsScoped("$trace", [
+			...prev,
+			item,
+		]);
+	});

--- a/apps/server/src/error/AccessDeniedError.ts
+++ b/apps/server/src/error/AccessDeniedError.ts
@@ -1,7 +1,0 @@
-import { Data } from "effect";
-
-export class AccessDeniedError extends Data.TaggedError("AccessDeniedError")<{
-	message: string;
-}> {
-	//
-}

--- a/apps/server/src/error/AccessDeniedErrorFx.ts
+++ b/apps/server/src/error/AccessDeniedErrorFx.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class AccessDeniedErrorFx extends Data.TaggedError("AccessDeniedErrorFx")<{
+	message: string;
+}> {
+	//
+}

--- a/apps/server/src/error/InfraErrorFx.ts
+++ b/apps/server/src/error/InfraErrorFx.ts
@@ -1,6 +1,6 @@
 import { Data } from "effect";
 
-export class InfraError extends Data.TaggedError("InfraError")<{
+export class InfraErrorFx extends Data.TaggedError("InfraErrorFx")<{
 	type: string;
 	message?: string;
 }> {

--- a/apps/server/src/error/InvalidRequestError.ts
+++ b/apps/server/src/error/InvalidRequestError.ts
@@ -1,7 +1,0 @@
-import { Data } from "effect";
-
-export class InvalidRequestError extends Data.TaggedError("InvalidRequestError")<{
-	message: string;
-}> {
-	//
-}

--- a/apps/server/src/error/InvalidRequestErrorFx.ts
+++ b/apps/server/src/error/InvalidRequestErrorFx.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class InvalidRequestErrorFx extends Data.TaggedError("InvalidRequestErrorFx")<{
+	message: string;
+}> {
+	//
+}

--- a/apps/server/src/error/NoContentErrorFx.ts
+++ b/apps/server/src/error/NoContentErrorFx.ts
@@ -1,6 +1,6 @@
 import { Data } from "effect";
 
-export class NoContentError extends Data.TaggedError("NoContentError")<{
+export class NoContentErrorFx extends Data.TaggedError("NoContentErrorFx")<{
 	resource: string;
 	message: string;
 }> {

--- a/apps/server/src/error/RuntimeErrorFx.ts
+++ b/apps/server/src/error/RuntimeErrorFx.ts
@@ -3,7 +3,7 @@ import { Data } from "effect";
 /**
  * General runtime error not belonging to a particular domain.
  */
-export class RuntimeError extends Data.TaggedError("RuntimeError")<{
+export class RuntimeErrorFx extends Data.TaggedError("RuntimeErrorFx")<{
 	message: string;
 }> {
 	//

--- a/apps/server/src/error/TooManyRequests.ts
+++ b/apps/server/src/error/TooManyRequests.ts
@@ -1,7 +1,0 @@
-import { Data } from "effect";
-
-export class TooManyRequests extends Data.TaggedError("TooManyRequests")<{
-	message: string;
-}> {
-	//
-}

--- a/apps/server/src/error/TooManyRequestsFx.ts
+++ b/apps/server/src/error/TooManyRequestsFx.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class TooManyRequestsFx extends Data.TaggedError("TooManyRequestsFx")<{
+	message: string;
+}> {
+	//
+}

--- a/apps/server/test/@user/user-event/fx/userEventBuyerInfoFx/single-event.test.ts
+++ b/apps/server/test/@user/user-event/fx/userEventBuyerInfoFx/single-event.test.ts
@@ -1,4 +1,4 @@
-import { createDateContext, DateContextLayer } from "@use-pico/common/date";
+import { DateContextLayer } from "@use-pico/common/date";
 import { Effect } from "effect";
 import { DateTime } from "luxon";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many API effects and error pathways; main risk is mismatched tagged-error names or changed catch mappings causing incorrect HTTP responses/log annotations.
> 
> **Overview**
> Standardizes server-side error handling and tracing to improve observability. Legacy tagged errors (`AccessDeniedError`, `InvalidRequestError`, `TooManyRequests`, `RuntimeError`, etc.) are replaced with `*ErrorFx` variants across buyer/seller/session/user flows, and route `withCatchFx` mappings are updated accordingly.
> 
> Introduces `withTraceFx` to accumulate a `$trace` annotation and replaces many `Effect.annotateLogsScoped` callsites with structured trace entries (including explicit trace events on notable error branches). Logging to Axiom is enhanced in `withLoggingFx` to attach `$catch`/`$fatal` error objects to logs, and `feedCreateFx` now wraps DB inserts to convert `pg` `DatabaseError` (and other failures) into `RuntimeErrorFx` so handlers can return consistent 500 notices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560dad0aae2e349b609abbd35af3b9bd5470ab8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->