### PR TITLE
Move Search link directly below Notifications in HomeMenu

### DIFF
--- a/apps/app/src/app/@user/home/HomeMenu/HomeMenu.tsx
+++ b/apps/app/src/app/@user/home/HomeMenu/HomeMenu.tsx
@@ -89,14 +89,7 @@ export const HomeMenu = ({ ui, onLinkClick, ...props }: HomeMenu.Props) => {
 				</Group>
 
 				<Group>
-					<ListingsLink
-						iconProps={{
-							ui: {
-								...icon,
-							},
-						}}
-					/>
-					<DraftLink
+					<SearchLink
 						iconProps={{
 							ui: {
 								...icon,
@@ -106,7 +99,14 @@ export const HomeMenu = ({ ui, onLinkClick, ...props }: HomeMenu.Props) => {
 				</Group>
 
 				<Group>
-					<SearchLink
+					<ListingsLink
+						iconProps={{
+							ui: {
+								...icon,
+							},
+						}}
+					/>
+					<DraftLink
 						iconProps={{
 							ui: {
 								...icon,


### PR DESCRIPTION
### Motivation
- Improve discoverability by placing the `SearchLink` immediately after the announcements/notifications entry in the home menu so users see search earlier in the navigation.

### Description
- Reordered the home menu links in `apps/app/src/app/@user/home/HomeMenu/HomeMenu.tsx` by moving the `SearchLink` group to appear directly after the `NotificationLink` group, preserving existing props, styling and behavior.

### Testing
- Ran `bun x biome check apps/app/src/app/@user/home/HomeMenu/HomeMenu.tsx` which completed successfully.
- Ran `cd apps/app && bun run typecheck` which completed successfully with no type errors.
- Launched the dev server with `cd apps/app && bun run dev` and ran a Playwright script to capture a screenshot of `/cs/home` which saved `artifacts/home-menu-search.png` confirming the visual change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8c59d9288323b3bdc4894f701fd3)