### PR TITLE
ZBA-282 Rework message navigation to use detail routes

### DIFF
--- a/apps/app/src/@routes/$locale/buyer/message/$transactionId.tsx
+++ b/apps/app/src/@routes/$locale/buyer/message/$transactionId.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { TransactionDetailPage } from "~/app/@buyer/transaction/~public/TransactionDetailPage";
+
+export const Route = createFileRoute("/$locale/buyer/message/$transactionId")({
+	component() {
+		const { transactionId } = Route.useParams();
+
+		return <TransactionDetailPage transactionId={transactionId} />;
+	},
+});

--- a/apps/app/src/@routes/$locale/seller/message/$listingId/$transactionId.tsx
+++ b/apps/app/src/@routes/$locale/seller/message/$listingId/$transactionId.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { TransactionDetailPage } from "~/app/@seller/transaction/~public/TransactionDetailPage";
+
+export const Route = createFileRoute("/$locale/seller/message/$listingId/$transactionId")({
+	component() {
+		const { transactionId } = Route.useParams();
+
+		return <TransactionDetailPage transactionId={transactionId} />;
+	},
+});

--- a/apps/app/src/_route.ts
+++ b/apps/app/src/_route.ts
@@ -25,10 +25,12 @@ import { Route as LocaleSellerListingMyRouteImport } from './@routes/$locale/sel
 import { Route as LocaleSellerDraftResolveRouteImport } from './@routes/$locale/seller/draft/resolve'
 import { Route as LocaleSellerDraftListRouteImport } from './@routes/$locale/seller/draft/list'
 import { Route as LocaleBuyerMessageListRouteImport } from './@routes/$locale/buyer/message/list'
+import { Route as LocaleBuyerMessageTransactionIdRouteImport } from './@routes/$locale/buyer/message/$transactionId'
 import { Route as LocaleBuyerFeedListRouteImport } from './@routes/$locale/buyer/feed/list'
 import { Route as LocaleBuyerFeedDefaultRouteImport } from './@routes/$locale/buyer/feed/default'
 import { Route as LocaleBuyerFavouriteListRouteImport } from './@routes/$locale/buyer/favourite/list'
 import { Route as LocaleSellerMessageListingIdListRouteImport } from './@routes/$locale/seller/message/$listingId/list'
+import { Route as LocaleSellerMessageListingIdTransactionIdRouteImport } from './@routes/$locale/seller/message/$listingId/$transactionId'
 import { Route as LocaleSellerDraftIdEditRouteImport } from './@routes/$locale/seller/draft/$id/edit'
 import { Route as LocaleBuyerFeedIdListRouteImport } from './@routes/$locale/buyer/feed/$id/list'
 import { Route as LocaleBuyerFeedIdFavouriteListRouteImport } from './@routes/$locale/buyer/feed/$id/favourite/list'
@@ -114,6 +116,12 @@ const LocaleBuyerMessageListRoute = LocaleBuyerMessageListRouteImport.update({
   path: '/buyer/message/list',
   getParentRoute: () => LocaleRoute,
 } as any)
+const LocaleBuyerMessageTransactionIdRoute =
+  LocaleBuyerMessageTransactionIdRouteImport.update({
+    id: '/buyer/message/$transactionId',
+    path: '/buyer/message/$transactionId',
+    getParentRoute: () => LocaleRoute,
+  } as any)
 const LocaleBuyerFeedListRoute = LocaleBuyerFeedListRouteImport.update({
   id: '/buyer/feed/list',
   path: '/buyer/feed/list',
@@ -134,6 +142,12 @@ const LocaleSellerMessageListingIdListRoute =
   LocaleSellerMessageListingIdListRouteImport.update({
     id: '/seller/message/$listingId/list',
     path: '/seller/message/$listingId/list',
+    getParentRoute: () => LocaleRoute,
+  } as any)
+const LocaleSellerMessageListingIdTransactionIdRoute =
+  LocaleSellerMessageListingIdTransactionIdRouteImport.update({
+    id: '/seller/message/$listingId/$transactionId',
+    path: '/seller/message/$listingId/$transactionId',
     getParentRoute: () => LocaleRoute,
   } as any)
 const LocaleSellerDraftIdEditRoute = LocaleSellerDraftIdEditRouteImport.update({
@@ -168,6 +182,7 @@ export interface FileRoutesByFullPath {
   '/$locale/buyer/favourite/list': typeof LocaleBuyerFavouriteListRoute
   '/$locale/buyer/feed/default': typeof LocaleBuyerFeedDefaultRoute
   '/$locale/buyer/feed/list': typeof LocaleBuyerFeedListRoute
+  '/$locale/buyer/message/$transactionId': typeof LocaleBuyerMessageTransactionIdRoute
   '/$locale/buyer/message/list': typeof LocaleBuyerMessageListRoute
   '/$locale/seller/draft/list': typeof LocaleSellerDraftListRoute
   '/$locale/seller/draft/resolve': typeof LocaleSellerDraftResolveRoute
@@ -175,6 +190,7 @@ export interface FileRoutesByFullPath {
   '/$locale/seller/message/list': typeof LocaleSellerMessageListRoute
   '/$locale/buyer/feed/$id/list': typeof LocaleBuyerFeedIdListRoute
   '/$locale/seller/draft/$id/edit': typeof LocaleSellerDraftIdEditRoute
+  '/$locale/seller/message/$listingId/$transactionId': typeof LocaleSellerMessageListingIdTransactionIdRoute
   '/$locale/seller/message/$listingId/list': typeof LocaleSellerMessageListingIdListRoute
   '/$locale/buyer/feed/$id/favourite/list': typeof LocaleBuyerFeedIdFavouriteListRoute
 }
@@ -192,6 +208,7 @@ export interface FileRoutesByTo {
   '/$locale/buyer/favourite/list': typeof LocaleBuyerFavouriteListRoute
   '/$locale/buyer/feed/default': typeof LocaleBuyerFeedDefaultRoute
   '/$locale/buyer/feed/list': typeof LocaleBuyerFeedListRoute
+  '/$locale/buyer/message/$transactionId': typeof LocaleBuyerMessageTransactionIdRoute
   '/$locale/buyer/message/list': typeof LocaleBuyerMessageListRoute
   '/$locale/seller/draft/list': typeof LocaleSellerDraftListRoute
   '/$locale/seller/draft/resolve': typeof LocaleSellerDraftResolveRoute
@@ -199,6 +216,7 @@ export interface FileRoutesByTo {
   '/$locale/seller/message/list': typeof LocaleSellerMessageListRoute
   '/$locale/buyer/feed/$id/list': typeof LocaleBuyerFeedIdListRoute
   '/$locale/seller/draft/$id/edit': typeof LocaleSellerDraftIdEditRoute
+  '/$locale/seller/message/$listingId/$transactionId': typeof LocaleSellerMessageListingIdTransactionIdRoute
   '/$locale/seller/message/$listingId/list': typeof LocaleSellerMessageListingIdListRoute
   '/$locale/buyer/feed/$id/favourite/list': typeof LocaleBuyerFeedIdFavouriteListRoute
 }
@@ -218,6 +236,7 @@ export interface FileRoutesById {
   '/$locale/buyer/favourite/list': typeof LocaleBuyerFavouriteListRoute
   '/$locale/buyer/feed/default': typeof LocaleBuyerFeedDefaultRoute
   '/$locale/buyer/feed/list': typeof LocaleBuyerFeedListRoute
+  '/$locale/buyer/message/$transactionId': typeof LocaleBuyerMessageTransactionIdRoute
   '/$locale/buyer/message/list': typeof LocaleBuyerMessageListRoute
   '/$locale/seller/draft/list': typeof LocaleSellerDraftListRoute
   '/$locale/seller/draft/resolve': typeof LocaleSellerDraftResolveRoute
@@ -225,6 +244,7 @@ export interface FileRoutesById {
   '/$locale/seller/message/list': typeof LocaleSellerMessageListRoute
   '/$locale/buyer/feed/$id/list': typeof LocaleBuyerFeedIdListRoute
   '/$locale/seller/draft/$id/edit': typeof LocaleSellerDraftIdEditRoute
+  '/$locale/seller/message/$listingId/$transactionId': typeof LocaleSellerMessageListingIdTransactionIdRoute
   '/$locale/seller/message/$listingId/list': typeof LocaleSellerMessageListingIdListRoute
   '/$locale/buyer/feed/$id/favourite/list': typeof LocaleBuyerFeedIdFavouriteListRoute
 }
@@ -245,6 +265,7 @@ export interface FileRouteTypes {
     | '/$locale/buyer/favourite/list'
     | '/$locale/buyer/feed/default'
     | '/$locale/buyer/feed/list'
+    | '/$locale/buyer/message/$transactionId'
     | '/$locale/buyer/message/list'
     | '/$locale/seller/draft/list'
     | '/$locale/seller/draft/resolve'
@@ -252,6 +273,7 @@ export interface FileRouteTypes {
     | '/$locale/seller/message/list'
     | '/$locale/buyer/feed/$id/list'
     | '/$locale/seller/draft/$id/edit'
+    | '/$locale/seller/message/$listingId/$transactionId'
     | '/$locale/seller/message/$listingId/list'
     | '/$locale/buyer/feed/$id/favourite/list'
   fileRoutesByTo: FileRoutesByTo
@@ -269,6 +291,7 @@ export interface FileRouteTypes {
     | '/$locale/buyer/favourite/list'
     | '/$locale/buyer/feed/default'
     | '/$locale/buyer/feed/list'
+    | '/$locale/buyer/message/$transactionId'
     | '/$locale/buyer/message/list'
     | '/$locale/seller/draft/list'
     | '/$locale/seller/draft/resolve'
@@ -276,6 +299,7 @@ export interface FileRouteTypes {
     | '/$locale/seller/message/list'
     | '/$locale/buyer/feed/$id/list'
     | '/$locale/seller/draft/$id/edit'
+    | '/$locale/seller/message/$listingId/$transactionId'
     | '/$locale/seller/message/$listingId/list'
     | '/$locale/buyer/feed/$id/favourite/list'
   id:
@@ -294,6 +318,7 @@ export interface FileRouteTypes {
     | '/$locale/buyer/favourite/list'
     | '/$locale/buyer/feed/default'
     | '/$locale/buyer/feed/list'
+    | '/$locale/buyer/message/$transactionId'
     | '/$locale/buyer/message/list'
     | '/$locale/seller/draft/list'
     | '/$locale/seller/draft/resolve'
@@ -301,6 +326,7 @@ export interface FileRouteTypes {
     | '/$locale/seller/message/list'
     | '/$locale/buyer/feed/$id/list'
     | '/$locale/seller/draft/$id/edit'
+    | '/$locale/seller/message/$listingId/$transactionId'
     | '/$locale/seller/message/$listingId/list'
     | '/$locale/buyer/feed/$id/favourite/list'
   fileRoutesById: FileRoutesById
@@ -426,6 +452,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LocaleBuyerMessageListRouteImport
       parentRoute: typeof LocaleRoute
     }
+    '/$locale/buyer/message/$transactionId': {
+      id: '/$locale/buyer/message/$transactionId'
+      path: '/buyer/message/$transactionId'
+      fullPath: '/$locale/buyer/message/$transactionId'
+      preLoaderRoute: typeof LocaleBuyerMessageTransactionIdRouteImport
+      parentRoute: typeof LocaleRoute
+    }
     '/$locale/buyer/feed/list': {
       id: '/$locale/buyer/feed/list'
       path: '/buyer/feed/list'
@@ -452,6 +485,13 @@ declare module '@tanstack/react-router' {
       path: '/seller/message/$listingId/list'
       fullPath: '/$locale/seller/message/$listingId/list'
       preLoaderRoute: typeof LocaleSellerMessageListingIdListRouteImport
+      parentRoute: typeof LocaleRoute
+    }
+    '/$locale/seller/message/$listingId/$transactionId': {
+      id: '/$locale/seller/message/$listingId/$transactionId'
+      path: '/seller/message/$listingId/$transactionId'
+      fullPath: '/$locale/seller/message/$listingId/$transactionId'
+      preLoaderRoute: typeof LocaleSellerMessageListingIdTransactionIdRouteImport
       parentRoute: typeof LocaleRoute
     }
     '/$locale/seller/draft/$id/edit': {
@@ -489,6 +529,7 @@ interface LocaleRouteChildren {
   LocaleBuyerFavouriteListRoute: typeof LocaleBuyerFavouriteListRoute
   LocaleBuyerFeedDefaultRoute: typeof LocaleBuyerFeedDefaultRoute
   LocaleBuyerFeedListRoute: typeof LocaleBuyerFeedListRoute
+  LocaleBuyerMessageTransactionIdRoute: typeof LocaleBuyerMessageTransactionIdRoute
   LocaleBuyerMessageListRoute: typeof LocaleBuyerMessageListRoute
   LocaleSellerDraftListRoute: typeof LocaleSellerDraftListRoute
   LocaleSellerDraftResolveRoute: typeof LocaleSellerDraftResolveRoute
@@ -496,6 +537,7 @@ interface LocaleRouteChildren {
   LocaleSellerMessageListRoute: typeof LocaleSellerMessageListRoute
   LocaleBuyerFeedIdListRoute: typeof LocaleBuyerFeedIdListRoute
   LocaleSellerDraftIdEditRoute: typeof LocaleSellerDraftIdEditRoute
+  LocaleSellerMessageListingIdTransactionIdRoute: typeof LocaleSellerMessageListingIdTransactionIdRoute
   LocaleSellerMessageListingIdListRoute: typeof LocaleSellerMessageListingIdListRoute
   LocaleBuyerFeedIdFavouriteListRoute: typeof LocaleBuyerFeedIdFavouriteListRoute
 }
@@ -511,6 +553,7 @@ const LocaleRouteChildren: LocaleRouteChildren = {
   LocaleBuyerFavouriteListRoute: LocaleBuyerFavouriteListRoute,
   LocaleBuyerFeedDefaultRoute: LocaleBuyerFeedDefaultRoute,
   LocaleBuyerFeedListRoute: LocaleBuyerFeedListRoute,
+  LocaleBuyerMessageTransactionIdRoute: LocaleBuyerMessageTransactionIdRoute,
   LocaleBuyerMessageListRoute: LocaleBuyerMessageListRoute,
   LocaleSellerDraftListRoute: LocaleSellerDraftListRoute,
   LocaleSellerDraftResolveRoute: LocaleSellerDraftResolveRoute,
@@ -518,6 +561,8 @@ const LocaleRouteChildren: LocaleRouteChildren = {
   LocaleSellerMessageListRoute: LocaleSellerMessageListRoute,
   LocaleBuyerFeedIdListRoute: LocaleBuyerFeedIdListRoute,
   LocaleSellerDraftIdEditRoute: LocaleSellerDraftIdEditRoute,
+  LocaleSellerMessageListingIdTransactionIdRoute:
+    LocaleSellerMessageListingIdTransactionIdRoute,
   LocaleSellerMessageListingIdListRoute: LocaleSellerMessageListingIdListRoute,
   LocaleBuyerFeedIdFavouriteListRoute: LocaleBuyerFeedIdFavouriteListRoute,
 }

--- a/apps/app/src/app/@buyer/transaction/MessageListPage/MessageListPage.tsx
+++ b/apps/app/src/app/@buyer/transaction/MessageListPage/MessageListPage.tsx
@@ -1,5 +1,9 @@
+import { useLocale } from "@use-pico/client/hook";
+import { ArrowLeftIcon } from "@use-pico/client/icon";
+import { LinkTo } from "@use-pico/client/ui/link-to";
 import { translator } from "@use-pico/common/translator";
 import { TitleContainer } from "@zbav-se.me/ui/container";
+import { uiBackButton } from "@zbav-se.me/ui/ui";
 import type { FC } from "react";
 import { HomeMenuButton } from "~/app/@user/home/~public/HomeMenuButton";
 import { TransactionList } from "~/app/v0/@buyer/transaction/ui/TransactionList";
@@ -11,9 +15,23 @@ export namespace MessageListPage {
 }
 
 export const MessageListPage: FC<MessageListPage.Props> = (props) => {
+	const locale = useLocale();
+
 	return (
 		<TitleContainer
 			textTitle={translator.text("Messages (title)")}
+			left={
+				<LinkTo
+					{...uiBackButton({
+						className: [],
+					})}
+					icon={ArrowLeftIcon}
+					to="/$locale/home"
+					params={{
+						locale,
+					}}
+				/>
+			}
 			right={<HomeMenuButton />}
 			{...props}
 		>

--- a/apps/app/src/app/@buyer/transaction/TransactionDetailPage/TransactionDetailPage.tsx
+++ b/apps/app/src/app/@buyer/transaction/TransactionDetailPage/TransactionDetailPage.tsx
@@ -4,21 +4,26 @@ import { LinkTo } from "@use-pico/client/ui/link-to";
 import { translator } from "@use-pico/common/translator";
 import { TitleContainer } from "@zbav-se.me/ui/container";
 import { uiBackButton } from "@zbav-se.me/ui/ui";
-import { type FC, Suspense } from "react";
+import type { FC } from "react";
+import { Suspense } from "react";
 import { HomeMenuButton } from "~/app/@user/home/~public/HomeMenuButton";
-import { TransactionListingList } from "~/app/v0/@seller/transaction-listing/ui/TransactionListingList";
-import { TransactionListingListPending } from "~/app/v0/@seller/transaction-listing/ui/TransactionListingListPending";
+import { Transaction } from "~/app/v0/@buyer/transaction/ui/Transaction";
+import { TransactionPending } from "~/app/v0/@buyer/transaction/ui/TransactionPending";
 
-export namespace MessageListPage {
-	export interface Props extends TitleContainer.Props {}
+export namespace TransactionDetailPage {
+	export interface Props extends TitleContainer.Props {
+		transactionId: string;
+	}
 }
 
-export const MessageListPage: FC<MessageListPage.Props> = (props) => {
+export const TransactionDetailPage: FC<TransactionDetailPage.Props> = ({
+	transactionId,
+	...props
+}) => {
 	const locale = useLocale();
 
 	return (
 		<TitleContainer
-			data-ui="SellerMessageList[TitleContainer]"
 			textTitle={translator.text("Messages (title)")}
 			left={
 				<LinkTo
@@ -35,20 +40,11 @@ export const MessageListPage: FC<MessageListPage.Props> = (props) => {
 			right={<HomeMenuButton />}
 			{...props}
 		>
-			<Suspense fallback={<TransactionListingListPending />}>
-				<TransactionListingList
+			<Suspense fallback={<TransactionPending />}>
+				<Transaction
 					_suspense={"I know"}
-					query={{
-						sort: [
-							{
-								field: "createdAt",
-								order: "desc",
-							},
-						],
-					}}
-					ui={{
-						inner: "default",
-					}}
+					transactionId={transactionId}
+					refresh={1_000 * 5}
 				/>
 			</Suspense>
 		</TitleContainer>

--- a/apps/app/src/app/@buyer/transaction/~public/TransactionDetailPage.ts
+++ b/apps/app/src/app/@buyer/transaction/~public/TransactionDetailPage.ts
@@ -1,0 +1,1 @@
+export { TransactionDetailPage } from "../TransactionDetailPage/TransactionDetailPage";

--- a/apps/app/src/app/@seller/transaction/TransactionDetailPage/TransactionDetailPage.tsx
+++ b/apps/app/src/app/@seller/transaction/TransactionDetailPage/TransactionDetailPage.tsx
@@ -4,21 +4,26 @@ import { LinkTo } from "@use-pico/client/ui/link-to";
 import { translator } from "@use-pico/common/translator";
 import { TitleContainer } from "@zbav-se.me/ui/container";
 import { uiBackButton } from "@zbav-se.me/ui/ui";
-import { type FC, Suspense } from "react";
+import type { FC } from "react";
+import { Suspense } from "react";
 import { HomeMenuButton } from "~/app/@user/home/~public/HomeMenuButton";
-import { TransactionListingList } from "~/app/v0/@seller/transaction-listing/ui/TransactionListingList";
-import { TransactionListingListPending } from "~/app/v0/@seller/transaction-listing/ui/TransactionListingListPending";
+import { Transaction } from "~/app/v0/@seller/transaction/ui/Transaction";
+import { TransactionPending } from "~/app/v0/@seller/transaction/ui/TransactionPending";
 
-export namespace MessageListPage {
-	export interface Props extends TitleContainer.Props {}
+export namespace TransactionDetailPage {
+	export interface Props extends TitleContainer.Props {
+		transactionId: string;
+	}
 }
 
-export const MessageListPage: FC<MessageListPage.Props> = (props) => {
+export const TransactionDetailPage: FC<TransactionDetailPage.Props> = ({
+	transactionId,
+	...props
+}) => {
 	const locale = useLocale();
 
 	return (
 		<TitleContainer
-			data-ui="SellerMessageList[TitleContainer]"
 			textTitle={translator.text("Messages (title)")}
 			left={
 				<LinkTo
@@ -35,20 +40,11 @@ export const MessageListPage: FC<MessageListPage.Props> = (props) => {
 			right={<HomeMenuButton />}
 			{...props}
 		>
-			<Suspense fallback={<TransactionListingListPending />}>
-				<TransactionListingList
+			<Suspense fallback={<TransactionPending />}>
+				<Transaction
 					_suspense={"I know"}
-					query={{
-						sort: [
-							{
-								field: "createdAt",
-								order: "desc",
-							},
-						],
-					}}
-					ui={{
-						inner: "default",
-					}}
+					transactionId={transactionId}
+					refresh={1_000 * 5}
 				/>
 			</Suspense>
 		</TitleContainer>

--- a/apps/app/src/app/@seller/transaction/~public/TransactionDetailPage.ts
+++ b/apps/app/src/app/@seller/transaction/~public/TransactionDetailPage.ts
@@ -1,0 +1,1 @@
+export { TransactionDetailPage } from "../TransactionDetailPage/TransactionDetailPage";

--- a/apps/app/src/app/@user/inbox/InboxListPage/InboxListPage.tsx
+++ b/apps/app/src/app/@user/inbox/InboxListPage/InboxListPage.tsx
@@ -1,6 +1,10 @@
+import { useLocale } from "@use-pico/client/hook";
+import { ArrowLeftIcon } from "@use-pico/client/icon";
+import { LinkTo } from "@use-pico/client/ui/link-to";
 import { translator } from "@use-pico/common/translator";
 import type { tInboxQuery } from "@zbav-se.me/sdk/api/user";
 import { TitleContainer } from "@zbav-se.me/ui/container";
+import { uiBackButton } from "@zbav-se.me/ui/ui";
 import type { FC } from "react";
 import { HomeMenuButton } from "~/app/@user/home/~public/HomeMenuButton";
 import { InboxList } from "./InboxList/InboxList";
@@ -12,9 +16,23 @@ export namespace InboxListPage {
 }
 
 export const InboxListPage: FC<InboxListPage.Props> = ({ query, ...props }) => {
+	const locale = useLocale();
+
 	return (
 		<TitleContainer
 			textTitle={translator.text("Inbox (title)")}
+			left={
+				<LinkTo
+					{...uiBackButton({
+						className: [],
+					})}
+					icon={ArrowLeftIcon}
+					to="/$locale/home"
+					params={{
+						locale,
+					}}
+				/>
+			}
 			right={<HomeMenuButton />}
 			{...props}
 		>

--- a/apps/app/src/app/@user/inbox/InboxListPage/payload/InboxBuyerMessageItem.tsx
+++ b/apps/app/src/app/@user/inbox/InboxListPage/payload/InboxBuyerMessageItem.tsx
@@ -30,10 +30,11 @@ export const InboxBuyerMessageItem: FC<InboxBuyerMessageItem.Props> = ({ item, p
 
 	return (
 		<LinkTo
-			to="/$locale/seller/message/$listingId/list"
+			to="/$locale/seller/message/$listingId/$transactionId"
 			params={{
 				locale,
 				listingId: payload.listingId,
+				transactionId: payload.transactionId,
 			}}
 			onClick={() => {
 				if (item.archivedAt) {

--- a/apps/app/src/app/@user/inbox/InboxListPage/payload/InboxSellerMessageItem.tsx
+++ b/apps/app/src/app/@user/inbox/InboxListPage/payload/InboxSellerMessageItem.tsx
@@ -30,9 +30,10 @@ export const InboxSellerMessageItem: FC<InboxSellerMessageItem.Props> = ({ item,
 
 	return (
 		<LinkTo
-			to="/$locale/buyer/message/list"
+			to="/$locale/buyer/message/$transactionId"
 			params={{
 				locale,
+				transactionId: payload.transactionId,
 			}}
 			onClick={() => {
 				if (item.archivedAt) {

--- a/apps/app/src/app/README.md
+++ b/apps/app/src/app/README.md
@@ -39,3 +39,7 @@ No buyer <-> seller imports.
 - Added user inbox route: `/$locale/inbox/$type` (`high` or `common`).
 - Home menu message entry now points to Inbox (`Inbox (label)`).
 - Existing buyer/seller message routes remain available for conversation flows.
+- Message conversation detail now uses dedicated routes instead of bottom sheets:
+  - `/$locale/buyer/message/$transactionId`
+  - `/$locale/seller/message/$listingId/$transactionId`
+- Message and inbox pages now use explicit back-to-home links.

--- a/apps/app/src/app/v0/@buyer/transaction/ui/TransactionItemSuspense/Data.tsx
+++ b/apps/app/src/app/v0/@buyer/transaction/ui/TransactionItemSuspense/Data.tsx
@@ -1,12 +1,13 @@
+import { useLocale } from "@use-pico/client/hook";
 import type { MarkSuspense } from "@use-pico/client/type";
 import { Container } from "@use-pico/client/ui/container";
+import { LinkTo } from "@use-pico/client/ui/link-to";
 import { Tx } from "@use-pico/client/ui/tx";
 import { withTransactionQuery } from "@zbav-se.me/sdk/query/buyer/transaction";
-import { type FC, useState } from "react";
+import type { FC } from "react";
 import { match } from "ts-pattern";
 import { useUpload } from "~/app/@common/gallery/hook/useUpload";
 import { ListItem } from "~/app/@common/list-item/ListItem";
-import { TransactionSheet } from "~/app/v0/@buyer/transaction/ui/TransactionSheet";
 
 export namespace Data {
 	export interface Props extends ListItem.PropsEx, MarkSuspense.Props {
@@ -15,12 +16,18 @@ export namespace Data {
 }
 
 export const Data: FC<Data.Props> = ({ _suspense, transactionId, ...props }) => {
-	const [isOpen, setIsOpen] = useState(false);
+	const locale = useLocale();
 	const { data: transaction } = withTransactionQuery.useFetchQuery(transactionId);
 	const hero = useUpload(transaction.gallery.items);
 
 	return (
-		<>
+		<LinkTo
+			to="/$locale/buyer/message/$transactionId"
+			params={{
+				locale,
+				transactionId,
+			}}
+		>
 			<ListItem
 				data-ui={"TransactionItem[Item]"}
 				hero={hero}
@@ -59,7 +66,6 @@ export const Data: FC<Data.Props> = ({ _suspense, transactionId, ...props }) => 
 						]}
 					/>
 				}
-				onClick={() => setIsOpen(true)}
 				{...props}
 			>
 				{match(transaction.status)
@@ -86,13 +92,6 @@ export const Data: FC<Data.Props> = ({ _suspense, transactionId, ...props }) => 
 					})
 					.exhaustive()}
 			</ListItem>
-
-			<TransactionSheet
-				transactionId={transactionId}
-				isOpen={isOpen}
-				onClose={() => setIsOpen(false)}
-				refresh={1_000 * 5}
-			/>
-		</>
+		</LinkTo>
 	);
 };

--- a/apps/app/src/app/v0/@seller/transaction-listing/page/ListingMessageListPage.tsx
+++ b/apps/app/src/app/v0/@seller/transaction-listing/page/ListingMessageListPage.tsx
@@ -1,6 +1,6 @@
 import { VisibilityProvider } from "@use-pico/client/context";
 import { useLocale } from "@use-pico/client/hook";
-import { ChevronLeftIcon } from "@use-pico/client/icon";
+import { ArrowLeftIcon } from "@use-pico/client/icon";
 import { createNoopVisibilityStore } from "@use-pico/client/store";
 import type { MarkSuspense } from "@use-pico/client/type";
 import { Container } from "@use-pico/client/ui/container";
@@ -9,6 +9,7 @@ import { translator } from "@use-pico/common/translator";
 import { withListingQuery } from "@zbav-se.me/sdk/query/seller/listing";
 import { TitleContainer } from "@zbav-se.me/ui/container";
 import { HeroImage } from "@zbav-se.me/ui/img";
+import { uiBackButton } from "@zbav-se.me/ui/ui";
 import { type FC, useState } from "react";
 import { useUpload } from "~/app/@common/gallery/hook/useUpload";
 import { HomeMenuButton } from "~/app/@user/home/~public/HomeMenuButton";
@@ -28,7 +29,6 @@ export const ListingMessageListPage: FC<ListingMessageListPage.Props> = ({
 }) => {
 	const locale = useLocale();
 	const { data: listing } = withListingQuery.useFetchQuery(listingId);
-
 	const [detail, setDetail] = useState(false);
 	const hero = useUpload(listing.gallery.items);
 
@@ -39,8 +39,11 @@ export const ListingMessageListPage: FC<ListingMessageListPage.Props> = ({
 			textSubtitle={listing.title}
 			left={
 				<LinkTo
-					icon={ChevronLeftIcon}
-					to="/$locale/seller/message/list"
+					{...uiBackButton({
+						className: [],
+					})}
+					icon={ArrowLeftIcon}
+					to="/$locale/home"
 					params={{
 						locale,
 					}}
@@ -84,6 +87,7 @@ export const ListingMessageListPage: FC<ListingMessageListPage.Props> = ({
 					ui={{
 						inner: "default",
 					}}
+					listingId={listingId}
 				/>
 			</Container>
 

--- a/apps/app/src/app/v0/@seller/transaction-listing/page/ListingMessageListPendingPage.tsx
+++ b/apps/app/src/app/v0/@seller/transaction-listing/page/ListingMessageListPendingPage.tsx
@@ -1,9 +1,10 @@
 import { useLocale } from "@use-pico/client/hook";
-import { ChevronLeftIcon } from "@use-pico/client/icon";
+import { ArrowLeftIcon } from "@use-pico/client/icon";
 import { SpinnerContainer } from "@use-pico/client/ui/container";
 import { LinkTo } from "@use-pico/client/ui/link-to";
 import { translator } from "@use-pico/common/translator";
 import { TitleContainer } from "@zbav-se.me/ui/container";
+import { uiBackButton } from "@zbav-se.me/ui/ui";
 import type { FC } from "react";
 
 export namespace ListingMessageListPendingPage {
@@ -19,8 +20,11 @@ export const ListingMessageListPendingPage: FC<ListingMessageListPendingPage.Pro
 			textTitle={translator.text("Messages (title)")}
 			left={
 				<LinkTo
-					icon={ChevronLeftIcon}
-					to="/$locale/seller/message/list"
+					{...uiBackButton({
+						className: [],
+					})}
+					icon={ArrowLeftIcon}
+					to="/$locale/home"
 					params={{
 						locale,
 					}}

--- a/apps/app/src/app/v0/@seller/transaction/ui/TransactionItemSuspense/Data.tsx
+++ b/apps/app/src/app/v0/@seller/transaction/ui/TransactionItemSuspense/Data.tsx
@@ -1,23 +1,39 @@
+import { useLocale } from "@use-pico/client/hook";
 import type { MarkSuspense } from "@use-pico/client/type";
 import { Container } from "@use-pico/client/ui/container";
+import { LinkTo } from "@use-pico/client/ui/link-to";
 import { Tx } from "@use-pico/client/ui/tx";
 import { withTransactionQuery } from "@zbav-se.me/sdk/query/seller/transaction";
-import { type FC, useState } from "react";
+import type { FC } from "react";
 import { match } from "ts-pattern";
-import { TransactionSheet } from "~/app/v0/@seller/transaction/ui/TransactionSheet";
 
 export namespace Data {
 	export interface Props extends Container.Props, MarkSuspense.Props {
 		transactionId: string;
+		listingId: string;
 	}
 }
 
-export const Data: FC<Data.Props> = ({ _suspense, transactionId, ui, className, ...props }) => {
-	const [isOpen, setIsOpen] = useState(false);
+export const Data: FC<Data.Props> = ({
+	_suspense,
+	transactionId,
+	listingId,
+	ui,
+	className,
+	...props
+}) => {
+	const locale = useLocale();
 	const { data: transaction } = withTransactionQuery.useFetchQuery(transactionId);
 
 	return (
-		<>
+		<LinkTo
+			to="/$locale/seller/message/$listingId/$transactionId"
+			params={{
+				locale,
+				listingId,
+				transactionId,
+			}}
+		>
 			<Container
 				ui={{
 					tone: "neutral",
@@ -33,7 +49,6 @@ export const Data: FC<Data.Props> = ({ _suspense, transactionId, ui, className, 
 					"h-48 md:h-92",
 					className,
 				]}
-				onClick={() => setIsOpen((prev) => !prev)}
 				{...props}
 			>
 				{match(transaction.status)
@@ -82,13 +97,6 @@ export const Data: FC<Data.Props> = ({ _suspense, transactionId, ui, className, 
 					/>
 				</Container>
 			</Container>
-
-			<TransactionSheet
-				transactionId={transactionId}
-				isOpen={isOpen}
-				onClose={() => setIsOpen(false)}
-				refresh={1_000 * 5}
-			/>
-		</>
+		</LinkTo>
 	);
 };

--- a/apps/app/src/app/v0/@seller/transaction/ui/TransactionList.tsx
+++ b/apps/app/src/app/v0/@seller/transaction/ui/TransactionList.tsx
@@ -8,10 +8,11 @@ import { TransactionListContainerPending } from "./TransactionListContainerPendi
 export namespace TransactionList {
 	export interface Props extends Container.Props {
 		query: tTransactionQuery;
+		listingId?: string;
 	}
 }
 
-export const TransactionList: FC<TransactionList.Props> = ({ query, ...props }) => {
+export const TransactionList: FC<TransactionList.Props> = ({ query, listingId, ...props }) => {
 	return (
 		<Suspense fallback={<TransactionListContainerPending />}>
 			<TransactionListContainer
@@ -22,6 +23,7 @@ export const TransactionList: FC<TransactionList.Props> = ({ query, ...props }) 
 						key={transactionId}
 						data-id={transactionId}
 						transactionId={transactionId}
+						listingId={listingId ?? query.where?.listingId ?? ""}
 					/>
 				)}
 				{...props}


### PR DESCRIPTION
## Summary
- replace buyer and seller message bottom-sheet previews with dedicated detail routes
- deep-link inbox message items into concrete conversation detail screens
- add explicit back-to-home navigation on inbox and message pages while keeping seller listing preview in a bottom sheet

## Testing
- bun run typecheck
- bun run lint