### PR TITLE
Add inbox reference and normalize transaction family

### DIFF
--- a/apps/server/src/@buyer/favourite/fx/favouriteToggleFx.ts
+++ b/apps/server/src/@buyer/favourite/fx/favouriteToggleFx.ts
@@ -57,6 +57,7 @@ export const favouriteToggleFx = Effect.fn("favouriteToggleFx")(function* ({
 
 						yield* inboxCreateFx({
 							userId: listingUserId,
+							reference: listingId,
 							family: "reaction",
 							type: "favourite",
 							payload: {
@@ -89,6 +90,7 @@ export const favouriteToggleFx = Effect.fn("favouriteToggleFx")(function* ({
 
 						yield* inboxCreateFx({
 							userId: listingUserId,
+							reference: listingId,
 							family: "reaction",
 							type: "unfavourite",
 							payload: {

--- a/apps/server/src/@buyer/thumb/fx/thumbCreateFx.ts
+++ b/apps/server/src/@buyer/thumb/fx/thumbCreateFx.ts
@@ -79,6 +79,7 @@ export const thumbCreateFx = Effect.fn("thumbCreateFx")(function* ({
 
 			yield* inboxCreateFx({
 				userId: listing.userId,
+				reference: listingId,
 				family: "reaction",
 				type: "thumb",
 				payload: {

--- a/apps/server/src/@buyer/transaction/fx/transactionCloseFx.ts
+++ b/apps/server/src/@buyer/transaction/fx/transactionCloseFx.ts
@@ -53,7 +53,8 @@ export const transactionCloseFx = Effect.fn("transactionCloseFx")(function* ({
 
 			yield* inboxCreateFx({
 				userId: transaction.sellerId,
-				family: "message",
+				reference: transaction.listingId,
+				family: "transaction",
 				type: "buyer-message",
 				payload: {
 					transactionId: transaction.id,

--- a/apps/server/src/@buyer/transaction/fx/transactionCreateFx.ts
+++ b/apps/server/src/@buyer/transaction/fx/transactionCreateFx.ts
@@ -134,7 +134,8 @@ export const transactionCreateFx = Effect.fn("transactionCreateFx")(function* ({
 
 			yield* inboxCreateFx({
 				userId: listing.userId,
-				family: "message",
+				reference: listingId,
+				family: "transaction",
 				type: "buyer-message",
 				payload: {
 					transactionId: id,

--- a/apps/server/src/@buyer/transaction/fx/transactionDisputeFx.ts
+++ b/apps/server/src/@buyer/transaction/fx/transactionDisputeFx.ts
@@ -52,7 +52,8 @@ export const transactionDisputeFx = Effect.fn("transactionDisputeFx")(function* 
 
 			yield* inboxCreateFx({
 				userId: transaction.sellerId,
-				family: "message",
+				reference: transaction.listingId,
+				family: "transaction",
 				type: "buyer-message",
 				payload: {
 					transactionId: transaction.id,

--- a/apps/server/src/@buyer/transaction/fx/transactionRejectFx.ts
+++ b/apps/server/src/@buyer/transaction/fx/transactionRejectFx.ts
@@ -53,7 +53,8 @@ export const transactionRejectFx = Effect.fn("transactionRejectFx")(function* ({
 
 			yield* inboxCreateFx({
 				userId: transaction.sellerId,
-				family: "message",
+				reference: transaction.listingId,
+				family: "transaction",
 				type: "buyer-message",
 				payload: {
 					transactionId: transaction.id,

--- a/apps/server/src/@buyer/transaction/fx/transactionSuccessFx.ts
+++ b/apps/server/src/@buyer/transaction/fx/transactionSuccessFx.ts
@@ -53,7 +53,8 @@ export const transactionSuccessFx = Effect.fn("transactionSuccessFx")(function* 
 
 			yield* inboxCreateFx({
 				userId: transaction.sellerId,
-				family: "message",
+				reference: transaction.listingId,
+				family: "transaction",
 				type: "buyer-message",
 				payload: {
 					transactionId: transaction.id,

--- a/apps/server/src/@seller/transaction/fx/transactionAcceptFx.ts
+++ b/apps/server/src/@seller/transaction/fx/transactionAcceptFx.ts
@@ -53,7 +53,8 @@ export const transactionAcceptFx = Effect.fn("transactionAcceptFx")(function* ({
 
 			yield* inboxCreateFx({
 				userId: transaction.buyerId,
-				family: "message",
+				reference: transaction.listingId,
+				family: "transaction",
 				type: "seller-message",
 				payload: {
 					transactionId: transaction.id,

--- a/apps/server/src/@seller/transaction/fx/transactionDisputeFx.ts
+++ b/apps/server/src/@seller/transaction/fx/transactionDisputeFx.ts
@@ -52,7 +52,8 @@ export const transactionDisputeFx = Effect.fn("transactionDisputeFx")(function* 
 
 			yield* inboxCreateFx({
 				userId: transaction.buyerId,
-				family: "message",
+				reference: transaction.listingId,
+				family: "transaction",
 				type: "seller-message",
 				payload: {
 					transactionId: transaction.id,

--- a/apps/server/src/@seller/transaction/fx/transactionRejectFx.ts
+++ b/apps/server/src/@seller/transaction/fx/transactionRejectFx.ts
@@ -53,7 +53,8 @@ export const transactionRejectFx = Effect.fn("transactionRejectFx")(function* ({
 
 			yield* inboxCreateFx({
 				userId: transaction.buyerId,
-				family: "message",
+				reference: transaction.listingId,
+				family: "transaction",
 				type: "seller-message",
 				payload: {
 					transactionId: transaction.id,

--- a/apps/server/src/@seller/transaction/fx/transactionResolveFx.ts
+++ b/apps/server/src/@seller/transaction/fx/transactionResolveFx.ts
@@ -53,7 +53,8 @@ export const transactionResolveFx = Effect.fn("transactionResolveFx")(function* 
 
 			yield* inboxCreateFx({
 				userId: transaction.buyerId,
-				family: "message",
+				reference: transaction.listingId,
+				family: "transaction",
 				type: "seller-message",
 				payload: {
 					transactionId: transaction.id,

--- a/apps/server/src/@user/README.md
+++ b/apps/server/src/@user/README.md
@@ -48,7 +48,7 @@ This domain handles all operations on user-owned, private data. Everything in th
 - **Archive** - Bulk archive selected items using `InboxQuery`
 - Inbox contracts are discriminated by root `type`, not by payload-only unions
 - Family:
-  - `message`
+  - `transaction`
   - `reaction`
 - Types:
   - `buyer-message`
@@ -60,11 +60,17 @@ This domain handles all operations on user-owned, private data. Everything in th
   - `favourite`
   - `unfavourite`
 - Transaction-like inbox payloads (`transaction`, `system`, `unknown`) carry `transactionId`, `listingId`, and recipient `target` so the app can deep-link into the correct buyer/seller transaction detail route.
+- Inbox rows now also store required normalized `reference` metadata. For the current inbox families, `reference` always equals the related `listingId` and can be used for grouping/filtering without reading payload variants.
 - Local Docker Compose upgrade for existing databases:
   - Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c 'ALTER TABLE "inbox" ADD COLUMN IF NOT EXISTS "family" text;'`
-- Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c "UPDATE \"inbox\" SET \"family\" = CASE WHEN \"type\" IN ('buyer-message', 'seller-message', 'transaction', 'system', 'unknown') THEN 'message' WHEN \"type\" IN ('thumb', 'favourite', 'unfavourite') THEN 'reaction' ELSE \"family\" END WHERE \"family\" IS NULL;"`
+- Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c "UPDATE \"inbox\" SET \"family\" = CASE WHEN \"type\" IN ('buyer-message', 'seller-message', 'transaction', 'system', 'unknown') THEN 'transaction' WHEN \"type\" IN ('thumb', 'favourite', 'unfavourite') THEN 'reaction' ELSE \"family\" END WHERE \"family\" IS NULL OR \"family\" = 'message';"`
   - Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c 'ALTER TABLE "inbox" ALTER COLUMN "family" SET NOT NULL;'`
   - Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c 'CREATE INDEX IF NOT EXISTS "inbox_[userId-family]_idx" ON "inbox" ("userId", "family");'`
+  - Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c 'ALTER TABLE "inbox" ADD COLUMN IF NOT EXISTS "reference" text;'`
+  - Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c "UPDATE \"inbox\" SET \"reference\" = \"payload\"->>'listingId' WHERE \"reference\" IS NULL;"`
+  - Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c "UPDATE \"inbox\" AS i SET \"reference\" = t.\"listingId\" FROM \"transaction\" AS t WHERE i.\"reference\" IS NULL AND i.\"payload\"->>'transactionId' = t.\"id\";"`
+  - Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c 'ALTER TABLE "inbox" ALTER COLUMN "reference" SET NOT NULL;'`
+  - Run `docker compose exec postgres psql -U postgres -d zbav_se_me -c 'CREATE INDEX IF NOT EXISTS "inbox_[userId-reference]_idx" ON "inbox" ("userId", "reference");'`
 
 ### Transaction Timeline
 - Transaction communication now enters through the unified **Transaction Entry** API.

--- a/apps/server/src/@user/inbox/db/withInboxQueryBuilderFx.ts
+++ b/apps/server/src/@user/inbox/db/withInboxQueryBuilderFx.ts
@@ -34,6 +34,10 @@ export const withInboxQueryBuilderFx = Effect.fn("withInboxQueryBuilderFx")(func
 		query = query.where("i.userId", "=", where.userId) as TSelect;
 	}
 
+	if (where.reference) {
+		query = query.where("i.reference", "=", where.reference) as TSelect;
+	}
+
 	if (where.family) {
 		query = query.where("i.family", "=", where.family) as TSelect;
 	}

--- a/apps/server/src/@user/inbox/fx/inboxCreateFx.ts
+++ b/apps/server/src/@user/inbox/fx/inboxCreateFx.ts
@@ -14,6 +14,7 @@ export namespace inboxCreateFx {
 
 export const inboxCreateFx = Effect.fn("inboxCreateFx")(function* ({
 	userId,
+	reference,
 	family,
 	type,
 	payload,
@@ -24,6 +25,7 @@ export const inboxCreateFx = Effect.fn("inboxCreateFx")(function* ({
 		message: "inboxCreateFx",
 		input: {
 			userId,
+			reference,
 			family,
 			type,
 			priority,
@@ -43,6 +45,7 @@ export const inboxCreateFx = Effect.fn("inboxCreateFx")(function* ({
 					.values({
 						id,
 						userId,
+						reference,
 						family,
 						type,
 						payload,

--- a/apps/server/src/@user/inbox/schema/InboxCreateSchema/BuyerMessageSchema.ts
+++ b/apps/server/src/@user/inbox/schema/InboxCreateSchema/BuyerMessageSchema.ts
@@ -4,7 +4,7 @@ import { InboxSchema } from "./InboxSchema";
 export const BuyerMessageSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("buyer-message"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/@user/inbox/schema/InboxCreateSchema/InboxSchema.ts
+++ b/apps/server/src/@user/inbox/schema/InboxCreateSchema/InboxSchema.ts
@@ -7,6 +7,9 @@ export const InboxSchema = z
 		userId: z.string().openapi({
 			description: "Recipient user identifier",
 		}),
+		reference: z.string().openapi({
+			description: "Normalized reference key used for inbox grouping",
+		}),
 		family: InboxFamilyEnumSchema,
 		priority: InboxPriorityEnumSchema,
 	})

--- a/apps/server/src/@user/inbox/schema/InboxCreateSchema/SellerMessageSchema.ts
+++ b/apps/server/src/@user/inbox/schema/InboxCreateSchema/SellerMessageSchema.ts
@@ -4,7 +4,7 @@ import { InboxSchema } from "./InboxSchema";
 export const SellerMessageSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("seller-message"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/@user/inbox/schema/InboxCreateSchema/SystemSchema.ts
+++ b/apps/server/src/@user/inbox/schema/InboxCreateSchema/SystemSchema.ts
@@ -5,7 +5,7 @@ import { InboxSchema } from "./InboxSchema";
 export const SystemSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("system"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/@user/inbox/schema/InboxCreateSchema/TransactionSchema.ts
+++ b/apps/server/src/@user/inbox/schema/InboxCreateSchema/TransactionSchema.ts
@@ -5,7 +5,7 @@ import { InboxSchema } from "./InboxSchema";
 export const TransactionSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("transaction"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/@user/inbox/schema/InboxCreateSchema/UnknownSchema.ts
+++ b/apps/server/src/@user/inbox/schema/InboxCreateSchema/UnknownSchema.ts
@@ -5,7 +5,7 @@ import { InboxSchema } from "./InboxSchema";
 export const UnknownSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("unknown"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/@user/inbox/schema/InboxFamilyEnumSchema.ts
+++ b/apps/server/src/@user/inbox/schema/InboxFamilyEnumSchema.ts
@@ -2,7 +2,7 @@ import { z } from "@hono/zod-openapi";
 
 export const InboxFamilyEnumSchema = z
 	.enum([
-		"message",
+		"transaction",
 		"reaction",
 	])
 	.openapi("InboxFamilyEnum", {

--- a/apps/server/src/@user/inbox/schema/InboxFilterSchema.ts
+++ b/apps/server/src/@user/inbox/schema/InboxFilterSchema.ts
@@ -10,6 +10,9 @@ export const InboxFilterSchema = z
 		userId: z.string().optional().openapi({
 			description: "Inbox owner filter",
 		}),
+		reference: z.string().optional().openapi({
+			description: "Normalized reference filter",
+		}),
 		family: InboxFamilyEnumSchema.optional(),
 		type: InboxTypeEnumSchema.optional(),
 		priority: InboxPriorityEnumSchema.optional(),

--- a/apps/server/src/@user/transaction-entry/fx/transactionEntryCreateFx.ts
+++ b/apps/server/src/@user/transaction-entry/fx/transactionEntryCreateFx.ts
@@ -242,7 +242,8 @@ export const transactionEntryCreateFx = Effect.fn("transactionEntryCreateFx")(fu
 				.with("buyer", () =>
 					inboxCreateFx({
 						userId: transaction.sellerId,
-						family: "message",
+						reference: transaction.listingId,
+						family: "transaction",
 						type: "buyer-message",
 						payload: {
 							transactionId: transaction.id,
@@ -254,7 +255,8 @@ export const transactionEntryCreateFx = Effect.fn("transactionEntryCreateFx")(fu
 				.with("seller", () =>
 					inboxCreateFx({
 						userId: transaction.buyerId,
-						family: "message",
+						reference: transaction.listingId,
+						family: "transaction",
 						type: "seller-message",
 						payload: {
 							transactionId: transaction.id,
@@ -267,7 +269,8 @@ export const transactionEntryCreateFx = Effect.fn("transactionEntryCreateFx")(fu
 					Effect.all([
 						inboxCreateFx({
 							userId: transaction.sellerId,
-							family: "message",
+							reference: transaction.listingId,
+							family: "transaction",
 							type: "transaction",
 							payload: {
 								transactionId: transaction.id,
@@ -279,7 +282,8 @@ export const transactionEntryCreateFx = Effect.fn("transactionEntryCreateFx")(fu
 						}),
 						inboxCreateFx({
 							userId: transaction.buyerId,
-							family: "message",
+							reference: transaction.listingId,
+							family: "transaction",
 							type: "transaction",
 							payload: {
 								transactionId: transaction.id,
@@ -295,7 +299,8 @@ export const transactionEntryCreateFx = Effect.fn("transactionEntryCreateFx")(fu
 					Effect.all([
 						inboxCreateFx({
 							userId: transaction.sellerId,
-							family: "message",
+							reference: transaction.listingId,
+							family: "transaction",
 							type: "system",
 							payload: {
 								transactionId: transaction.id,
@@ -307,7 +312,8 @@ export const transactionEntryCreateFx = Effect.fn("transactionEntryCreateFx")(fu
 						}),
 						inboxCreateFx({
 							userId: transaction.buyerId,
-							family: "message",
+							reference: transaction.listingId,
+							family: "transaction",
 							type: "system",
 							payload: {
 								transactionId: transaction.id,

--- a/apps/server/src/database/@table/InboxTableSchema/BuyerMessageSchema.ts
+++ b/apps/server/src/database/@table/InboxTableSchema/BuyerMessageSchema.ts
@@ -4,7 +4,7 @@ import { InboxSchema } from "./InboxSchema";
 export const BuyerMessageSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("buyer-message"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/database/@table/InboxTableSchema/InboxSchema.ts
+++ b/apps/server/src/database/@table/InboxTableSchema/InboxSchema.ts
@@ -10,6 +10,9 @@ export const InboxSchema = z
 		userId: z.string().openapi({
 			description: "Recipient user identifier",
 		}),
+		reference: z.string().openapi({
+			description: "Normalized reference key used for inbox grouping",
+		}),
 		timestamp: z.coerce.date().openapi({
 			description: "Inbox event timestamp",
 			type: "string",

--- a/apps/server/src/database/@table/InboxTableSchema/SellerMessageSchema.ts
+++ b/apps/server/src/database/@table/InboxTableSchema/SellerMessageSchema.ts
@@ -4,7 +4,7 @@ import { InboxSchema } from "./InboxSchema";
 export const SellerMessageSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("seller-message"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/database/@table/InboxTableSchema/SystemSchema.ts
+++ b/apps/server/src/database/@table/InboxTableSchema/SystemSchema.ts
@@ -5,7 +5,7 @@ import { InboxSchema } from "./InboxSchema";
 export const SystemSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("system"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/database/@table/InboxTableSchema/TransactionSchema.ts
+++ b/apps/server/src/database/@table/InboxTableSchema/TransactionSchema.ts
@@ -5,7 +5,7 @@ import { InboxSchema } from "./InboxSchema";
 export const TransactionSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("transaction"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/database/@table/InboxTableSchema/UnknownSchema.ts
+++ b/apps/server/src/database/@table/InboxTableSchema/UnknownSchema.ts
@@ -5,7 +5,7 @@ import { InboxSchema } from "./InboxSchema";
 export const UnknownSchema = z
 	.looseObject({
 		...InboxSchema.shape,
-		family: z.literal("message"),
+		family: z.literal("transaction"),
 		type: z.literal("unknown"),
 		payload: z.looseObject({
 			transactionId: z.string().openapi({

--- a/apps/server/src/database/migrations/0023-inbox.ts
+++ b/apps/server/src/database/migrations/0023-inbox.ts
@@ -34,6 +34,7 @@ export const InboxMigration: Migration = {
 			.createTable("inbox")
 			.addColumn("id", "text", (col) => col.primaryKey().notNull())
 			.addColumn("userId", "text", (col) => col.notNull())
+			.addColumn("reference", "text", (col) => col.notNull())
 			.addColumn("timestamp", "timestamptz", (col) => col.notNull())
 			.addColumn("family", "text", (col) => col.notNull())
 			.addColumn("type", sql`inbox_type_enum`, (col) => col.notNull())
@@ -75,6 +76,15 @@ export const InboxMigration: Migration = {
 			.columns([
 				"userId",
 				"family",
+			])
+			.execute();
+
+		await db.schema
+			.createIndex("inbox_[userId-reference]_idx")
+			.on("inbox")
+			.columns([
+				"userId",
+				"reference",
 			])
 			.execute();
 	},

--- a/apps/server/test/@user/inbox/fx/inboxFamilyFiltering.test.ts
+++ b/apps/server/test/@user/inbox/fx/inboxFamilyFiltering.test.ts
@@ -29,8 +29,9 @@ describe("inbox family", () => {
 				{
 					id: "inbox-message",
 					userId: user.id,
+					reference: "listing-1",
 					timestamp: new Date("2026-03-09T09:00:00.000Z"),
-					family: "message",
+					family: "transaction",
 					type: "buyer-message",
 					payload: {
 						transactionId: "tx-1",
@@ -41,6 +42,7 @@ describe("inbox family", () => {
 				{
 					id: "inbox-reaction",
 					userId: user.id,
+					reference: "listing-1",
 					timestamp: new Date("2026-03-09T10:00:00.000Z"),
 					family: "reaction",
 					type: "thumb",
@@ -60,7 +62,7 @@ describe("inbox family", () => {
 				select,
 				where: {
 					userId: user.id,
-					family: "message",
+					family: "transaction",
 				},
 			});
 
@@ -69,20 +71,85 @@ describe("inbox family", () => {
 
 		expect(rows).toHaveLength(1);
 		expect(rows[0]?.id).toBe("inbox-message");
-		expect(rows[0]?.family).toBe("message");
+		expect(rows[0]?.family).toBe("transaction");
 	});
 
 	it("accepts only known family values in where schema", () => {
 		expect(
 			InboxWhereSchema.parse({
-				family: "message",
+				family: "transaction",
 			}).family,
-		).toBe("message");
+		).toBe("transaction");
 
 		expect(() =>
 			InboxWhereSchema.parse({
 				family: "whatever",
 			}),
 		).toThrow();
+	});
+
+	it("filters inbox rows by normalized reference", async () => {
+		const database = await testabase("inboxFamilyFiltering-reference");
+
+		const { api } = auth(() => {
+			return database.dialect;
+		});
+
+		const { user } = await api.signUpEmail({
+			body: {
+				email: "inbox-reference@test.cz",
+				name: "Inbox Reference",
+				password: "12345678",
+			},
+		});
+
+		await database.kysely
+			.insertInto("inbox")
+			.values([
+				{
+					id: "inbox-reference-a",
+					userId: user.id,
+					reference: "listing-a",
+					timestamp: new Date("2026-03-09T09:00:00.000Z"),
+					family: "transaction",
+					type: "buyer-message",
+					payload: {
+						transactionId: "tx-a",
+					},
+					priority: "high",
+					archivedAt: null,
+				},
+				{
+					id: "inbox-reference-b",
+					userId: user.id,
+					reference: "listing-b",
+					timestamp: new Date("2026-03-09T10:00:00.000Z"),
+					family: "reaction",
+					type: "favourite",
+					payload: {
+						listingId: "listing-b",
+					},
+					priority: "common",
+					archivedAt: null,
+				},
+			])
+			.execute();
+
+		const rows = await Effect.gen(function* () {
+			const select = yield* withInboxSelectFx({});
+			const query = yield* withInboxQueryBuilderFx({
+				select,
+				where: {
+					userId: user.id,
+					reference: "listing-b",
+				},
+			});
+
+			return yield* Effect.promise(async () => query.execute());
+		}).pipe(withKyselyFx(database), Effect.runPromise);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.id).toBe("inbox-reference-b");
+		expect(rows[0]?.reference).toBe("listing-b");
 	});
 });

--- a/apps/server/test/@user/inbox/fx/inboxReference.test.ts
+++ b/apps/server/test/@user/inbox/fx/inboxReference.test.ts
@@ -1,0 +1,228 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { transactionCreateFx } from "~/@buyer/transaction/fx/transactionCreateFx";
+import { thumbCreateFx } from "~/@buyer/thumb/fx/thumbCreateFx";
+import { withUploadFx } from "~/@common/upload/context/withUploadFx";
+import { withTransactionContextFx } from "~/@common/transaction/context/TransactionContextFx";
+import { listingCreateFx } from "~/@seller/listing/fx/listingCreateFx";
+import { categoryFetchFx } from "~/@session/category/fx/categoryFetchFx";
+import { locationAutocompleteFx } from "~/@session/location/fx/locationAutocompleteFx";
+import { withLocationFx } from "~/@session/location/fx/withLocationFx";
+import { inboxCreateFx } from "~/@user/inbox/fx/inboxCreateFx";
+import { uploadCreateFx } from "~/@user/upload/fx/uploadCreateFx";
+import { auth } from "~/auth/auth";
+import { withDateFx } from "~/database/fx/withDateFx";
+import { withKyselyFx } from "~/database/fx/withKyselyFx";
+import { ServerGeoapifySchema } from "~/schema/env/ServerGeoapifySchema";
+import { testabase } from "~test/testabase";
+import { withTestAxiomFx } from "~test/withTestAxiomFx";
+
+interface ListingFixture {
+	listingId: string;
+	sellerId: string;
+	buyerId: string;
+}
+
+const withInboxRuntimeFx = (database: Awaited<ReturnType<typeof testabase>>) => {
+	const geoapifyConfig = ServerGeoapifySchema.parse(process.env);
+
+	return <A, E, R>(eff: Effect.Effect<A, E, R>) =>
+		eff.pipe(
+			withKyselyFx(database),
+			withDateFx,
+			withTestAxiomFx,
+			withTransactionContextFx(),
+			withLocationFx({
+				api: "https://api.geoapify.com",
+				autocomplete: "/v1/geocode/autocomplete",
+				geoapifyToken: geoapifyConfig.SERVER_GEOAPIFY_TOKEN,
+			}),
+			withUploadFx({
+				cdn: "https://cdn.zbav-se.me",
+			}),
+			Effect.scoped,
+		);
+};
+
+const createListingFixtureFx = ({
+	buyerId,
+	sellerId,
+}: Omit<ListingFixture, "listingId">) =>
+	Effect.gen(function* () {
+		const category = yield* categoryFetchFx({
+			where: {
+				slug: "pocitace-a-kancelar--uloziste-ssd-hdd",
+			},
+			scope: {},
+		});
+
+		const location = yield* locationAutocompleteFx({
+			lang: "cs",
+			text: "Praha",
+			limit: 1,
+		});
+
+		expect(location).toHaveLength(1);
+
+		const upload = yield* uploadCreateFx({
+			url: "https://cdn.zbav-se.me/test.jpg",
+			userId: sellerId,
+		});
+
+		const listing = yield* listingCreateFx({
+			age: 1,
+			condition: 1,
+			categoryId: category.id,
+			expiresAt: "1-month",
+			// biome-ignore lint/style/noNonNullAssertion: Asserted above.
+			locationId: location[0]!.id,
+			price: 100,
+			priceType: "open",
+			restriction: "none",
+			title: "Reference fixture listing",
+			uploadIds: [
+				upload.id,
+			],
+			userId: sellerId,
+		});
+
+		return {
+			buyerId,
+			listingId: listing.id,
+			sellerId,
+		} satisfies ListingFixture;
+	});
+
+describe("inbox reference", () => {
+	it("persists normalized reference during direct inbox creation", async () => {
+		const database = await testabase("inboxReference-direct-create");
+
+		const { api } = auth(() => {
+			return database.dialect;
+		});
+
+		const { user } = await api.signUpEmail({
+			body: {
+				email: "inbox-reference-direct@test.cz",
+				name: "Inbox Direct",
+				password: "12345678",
+			},
+		});
+
+		const inbox = await Effect.gen(function* () {
+			return yield* inboxCreateFx({
+				userId: user.id,
+				reference: "listing-direct",
+				family: "reaction",
+				type: "favourite",
+				payload: {
+					listingId: "listing-direct",
+				},
+				priority: "common",
+			});
+		}).pipe(withInboxRuntimeFx(database), Effect.runPromise);
+
+		expect(inbox.reference).toBe("listing-direct");
+	});
+
+	it("maps transaction inbox reference from listingId", async () => {
+		const database = await testabase("inboxReference-transaction-create");
+
+		const { api } = auth(() => {
+			return database.dialect;
+		});
+
+		const { user: seller } = await api.signUpEmail({
+			body: {
+				email: "inbox-reference-seller@test.cz",
+				name: "Seller Ref",
+				password: "12345678",
+			},
+		});
+
+		const { user: buyer } = await api.signUpEmail({
+			body: {
+				email: "inbox-reference-buyer@test.cz",
+				name: "Buyer Ref",
+				password: "12345678",
+			},
+		});
+
+		const fixture = await createListingFixtureFx({
+			buyerId: buyer.id,
+			sellerId: seller.id,
+		}).pipe(withInboxRuntimeFx(database), Effect.runPromise);
+
+		await Effect.gen(function* () {
+			yield* transactionCreateFx({
+				listingId: fixture.listingId,
+				userId: fixture.buyerId,
+			});
+		}).pipe(withInboxRuntimeFx(database), Effect.runPromise);
+
+		const inbox = await database.kysely
+			.selectFrom("inbox")
+			.select([
+				"id",
+				"reference",
+				"type",
+				"userId",
+			])
+			.where("userId", "=", fixture.sellerId)
+			.where("type", "=", "buyer-message")
+			.executeTakeFirstOrThrow();
+
+		expect(inbox.reference).toBe(fixture.listingId);
+	});
+
+	it("maps reaction inbox reference from listingId", async () => {
+		const database = await testabase("inboxReference-thumb-create");
+
+		const { api } = auth(() => {
+			return database.dialect;
+		});
+
+		const { user: seller } = await api.signUpEmail({
+			body: {
+				email: "inbox-reference-thumb-seller@test.cz",
+				name: "Seller Thumb",
+				password: "12345678",
+			},
+		});
+
+		const { user: buyer } = await api.signUpEmail({
+			body: {
+				email: "inbox-reference-thumb-buyer@test.cz",
+				name: "Buyer Thumb",
+				password: "12345678",
+			},
+		});
+
+		const fixture = await createListingFixtureFx({
+			buyerId: buyer.id,
+			sellerId: seller.id,
+		}).pipe(withInboxRuntimeFx(database), Effect.runPromise);
+
+		await Effect.gen(function* () {
+			yield* thumbCreateFx({
+				listingId: fixture.listingId,
+				type: "like",
+				userId: fixture.buyerId,
+			});
+		}).pipe(withInboxRuntimeFx(database), Effect.runPromise);
+
+		const inbox = await database.kysely
+			.selectFrom("inbox")
+			.select([
+				"id",
+				"reference",
+				"type",
+				"userId",
+			])
+			.where("userId", "=", fixture.sellerId)
+			.where("type", "=", "thumb")
+			.executeTakeFirstOrThrow();
+
+		expect(inbox.reference).toBe(fixture.listingId);
+	});
+});

--- a/packages/@zbav-se.me/sdk/src/api/user/schemas.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/user/schemas.gen.ts
@@ -281,6 +281,9 @@ export const sInboxFilter = {
         userId: {
             type: 'string'
         },
+        reference: {
+            type: 'string'
+        },
         family: {
             $ref: '#/components/schemas/InboxFamilyEnum'
         },
@@ -305,7 +308,7 @@ export const sInboxFilter = {
 export const sInboxFamilyEnum = {
     type: 'string',
     enum: [
-        'message',
+        'transaction',
         'reaction'
     ]
 } as const;
@@ -348,6 +351,9 @@ export const sInboxWhere = {
             type: 'string'
         },
         userId: {
+            type: 'string'
+        },
+        reference: {
             type: 'string'
         },
         family: {
@@ -447,13 +453,16 @@ export const sInboxBuyerMessage = {
         userId: {
             type: 'string'
         },
+        reference: {
+            type: 'string'
+        },
         timestamp: {
             type: 'string'
         },
         family: {
             type: 'string',
             enum: [
-                'message'
+                'transaction'
             ]
         },
         priority: {
@@ -491,6 +500,7 @@ export const sInboxBuyerMessage = {
     required: [
         'id',
         'userId',
+        'reference',
         'timestamp',
         'family',
         'priority',
@@ -509,13 +519,16 @@ export const sInboxSellerMessage = {
         userId: {
             type: 'string'
         },
+        reference: {
+            type: 'string'
+        },
         timestamp: {
             type: 'string'
         },
         family: {
             type: 'string',
             enum: [
-                'message'
+                'transaction'
             ]
         },
         priority: {
@@ -553,6 +566,7 @@ export const sInboxSellerMessage = {
     required: [
         'id',
         'userId',
+        'reference',
         'timestamp',
         'family',
         'priority',
@@ -571,13 +585,16 @@ export const sInboxTransaction = {
         userId: {
             type: 'string'
         },
+        reference: {
+            type: 'string'
+        },
         timestamp: {
             type: 'string'
         },
         family: {
             type: 'string',
             enum: [
-                'message'
+                'transaction'
             ]
         },
         priority: {
@@ -623,6 +640,7 @@ export const sInboxTransaction = {
     required: [
         'id',
         'userId',
+        'reference',
         'timestamp',
         'family',
         'priority',
@@ -649,13 +667,16 @@ export const sInboxSystem = {
         userId: {
             type: 'string'
         },
+        reference: {
+            type: 'string'
+        },
         timestamp: {
             type: 'string'
         },
         family: {
             type: 'string',
             enum: [
-                'message'
+                'transaction'
             ]
         },
         priority: {
@@ -701,6 +722,7 @@ export const sInboxSystem = {
     required: [
         'id',
         'userId',
+        'reference',
         'timestamp',
         'family',
         'priority',
@@ -719,13 +741,16 @@ export const sInboxUnknown = {
         userId: {
             type: 'string'
         },
+        reference: {
+            type: 'string'
+        },
         timestamp: {
             type: 'string'
         },
         family: {
             type: 'string',
             enum: [
-                'message'
+                'transaction'
             ]
         },
         priority: {
@@ -771,6 +796,7 @@ export const sInboxUnknown = {
     required: [
         'id',
         'userId',
+        'reference',
         'timestamp',
         'family',
         'priority',
@@ -787,6 +813,9 @@ export const sInboxThumb = {
             type: 'string'
         },
         userId: {
+            type: 'string'
+        },
+        reference: {
             type: 'string'
         },
         timestamp: {
@@ -834,6 +863,7 @@ export const sInboxThumb = {
     required: [
         'id',
         'userId',
+        'reference',
         'timestamp',
         'family',
         'priority',
@@ -858,6 +888,9 @@ export const sInboxFavourite = {
             type: 'string'
         },
         userId: {
+            type: 'string'
+        },
+        reference: {
             type: 'string'
         },
         timestamp: {
@@ -901,6 +934,7 @@ export const sInboxFavourite = {
     required: [
         'id',
         'userId',
+        'reference',
         'timestamp',
         'family',
         'priority',
@@ -917,6 +951,9 @@ export const sInboxUnfavourite = {
             type: 'string'
         },
         userId: {
+            type: 'string'
+        },
+        reference: {
             type: 'string'
         },
         timestamp: {
@@ -960,6 +997,7 @@ export const sInboxUnfavourite = {
     required: [
         'id',
         'userId',
+        'reference',
         'timestamp',
         'family',
         'priority',

--- a/packages/@zbav-se.me/sdk/src/api/user/types.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/user/types.gen.ts
@@ -240,6 +240,10 @@ export type tInboxFilter = {
      * Inbox owner filter
      */
     userId?: string;
+    /**
+     * Normalized reference filter
+     */
+    reference?: string;
     family?: tInboxFamilyEnum;
     type?: tInboxTypeEnum;
     priority?: tInboxPriorityEnum;
@@ -260,7 +264,7 @@ export type tInboxFilter = {
 /**
  * Inbox family
  */
-export const tInboxFamilyEnum = { message: 'message', reaction: 'reaction' } as const;
+export const tInboxFamilyEnum = { transaction: 'transaction', reaction: 'reaction' } as const;
 
 /**
  * Inbox family
@@ -316,6 +320,10 @@ export type tInboxWhere = {
      * Inbox owner filter
      */
     userId?: string;
+    /**
+     * Normalized reference filter
+     */
+    reference?: string;
     family?: tInboxFamilyEnum;
     type?: tInboxTypeEnum;
     priority?: tInboxPriorityEnum;
@@ -386,10 +394,14 @@ export type tInboxBuyerMessage = {
      */
     userId: string;
     /**
+     * Normalized reference key used for inbox grouping
+     */
+    reference: string;
+    /**
      * Inbox event timestamp
      */
     timestamp: string;
-    family: 'message';
+    family: 'transaction';
     priority: tInboxPriorityEnum;
     /**
      * Archive timestamp (null = active)
@@ -419,10 +431,14 @@ export type tInboxSellerMessage = {
      */
     userId: string;
     /**
+     * Normalized reference key used for inbox grouping
+     */
+    reference: string;
+    /**
      * Inbox event timestamp
      */
     timestamp: string;
-    family: 'message';
+    family: 'transaction';
     priority: tInboxPriorityEnum;
     /**
      * Archive timestamp (null = active)
@@ -452,10 +468,14 @@ export type tInboxTransaction = {
      */
     userId: string;
     /**
+     * Normalized reference key used for inbox grouping
+     */
+    reference: string;
+    /**
      * Inbox event timestamp
      */
     timestamp: string;
-    family: 'message';
+    family: 'transaction';
     priority: tInboxPriorityEnum;
     /**
      * Archive timestamp (null = active)
@@ -500,10 +520,14 @@ export type tInboxSystem = {
      */
     userId: string;
     /**
+     * Normalized reference key used for inbox grouping
+     */
+    reference: string;
+    /**
      * Inbox event timestamp
      */
     timestamp: string;
-    family: 'message';
+    family: 'transaction';
     priority: tInboxPriorityEnum;
     /**
      * Archive timestamp (null = active)
@@ -538,10 +562,14 @@ export type tInboxUnknown = {
      */
     userId: string;
     /**
+     * Normalized reference key used for inbox grouping
+     */
+    reference: string;
+    /**
      * Inbox event timestamp
      */
     timestamp: string;
-    family: 'message';
+    family: 'transaction';
     priority: tInboxPriorityEnum;
     /**
      * Archive timestamp (null = active)
@@ -575,6 +603,10 @@ export type tInboxThumb = {
      * Recipient user identifier
      */
     userId: string;
+    /**
+     * Normalized reference key used for inbox grouping
+     */
+    reference: string;
     /**
      * Inbox event timestamp
      */
@@ -616,6 +648,10 @@ export type tInboxFavourite = {
      */
     userId: string;
     /**
+     * Normalized reference key used for inbox grouping
+     */
+    reference: string;
+    /**
      * Inbox event timestamp
      */
     timestamp: string;
@@ -644,6 +680,10 @@ export type tInboxUnfavourite = {
      * Recipient user identifier
      */
     userId: string;
+    /**
+     * Normalized reference key used for inbox grouping
+     */
+    reference: string;
     /**
      * Inbox event timestamp
      */

--- a/packages/@zbav-se.me/sdk/src/api/user/zod.gen.ts
+++ b/packages/@zbav-se.me/sdk/src/api/user/zod.gen.ts
@@ -228,7 +228,7 @@ export type zGalleryCountQuery = z.infer<typeof zGalleryCountQuery>;
 /**
  * Inbox family
  */
-export const zInboxFamilyEnum = z.enum(['message', 'reaction']).register(z.globalRegistry, {
+export const zInboxFamilyEnum = z.enum(['transaction', 'reaction']).register(z.globalRegistry, {
     description: 'Inbox family'
 });
 
@@ -277,6 +277,9 @@ export const zInboxFilter = z.object({
     userId: z.string().register(z.globalRegistry, {
         description: 'Inbox owner filter'
     }).optional(),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference filter'
+    }).optional(),
     family: zInboxFamilyEnum.optional(),
     type: zInboxTypeEnum.optional(),
     priority: zInboxPriorityEnum.optional(),
@@ -310,6 +313,9 @@ export const zInboxWhere = z.object({
     }).optional(),
     userId: z.string().register(z.globalRegistry, {
         description: 'Inbox owner filter'
+    }).optional(),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference filter'
     }).optional(),
     family: zInboxFamilyEnum.optional(),
     type: zInboxTypeEnum.optional(),
@@ -375,10 +381,13 @@ export const zInboxBuyerMessage = z.object({
     userId: z.string().register(z.globalRegistry, {
         description: 'Recipient user identifier'
     }),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference key used for inbox grouping'
+    }),
     timestamp: z.string().register(z.globalRegistry, {
         description: 'Inbox event timestamp'
     }),
-    family: z.enum(['message']),
+    family: z.enum(['transaction']),
     priority: zInboxPriorityEnum,
     archivedAt: z.iso.datetime().nullable(),
     type: z.enum(['buyer-message']),
@@ -401,10 +410,13 @@ export const zInboxSellerMessage = z.object({
     userId: z.string().register(z.globalRegistry, {
         description: 'Recipient user identifier'
     }),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference key used for inbox grouping'
+    }),
     timestamp: z.string().register(z.globalRegistry, {
         description: 'Inbox event timestamp'
     }),
-    family: z.enum(['message']),
+    family: z.enum(['transaction']),
     priority: zInboxPriorityEnum,
     archivedAt: z.iso.datetime().nullable(),
     type: z.enum(['seller-message']),
@@ -436,10 +448,13 @@ export const zInboxTransaction = z.object({
     userId: z.string().register(z.globalRegistry, {
         description: 'Recipient user identifier'
     }),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference key used for inbox grouping'
+    }),
     timestamp: z.string().register(z.globalRegistry, {
         description: 'Inbox event timestamp'
     }),
-    family: z.enum(['message']),
+    family: z.enum(['transaction']),
     priority: zInboxPriorityEnum,
     archivedAt: z.iso.datetime().nullable(),
     type: z.enum(['transaction']),
@@ -466,10 +481,13 @@ export const zInboxSystem = z.object({
     userId: z.string().register(z.globalRegistry, {
         description: 'Recipient user identifier'
     }),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference key used for inbox grouping'
+    }),
     timestamp: z.string().register(z.globalRegistry, {
         description: 'Inbox event timestamp'
     }),
-    family: z.enum(['message']),
+    family: z.enum(['transaction']),
     priority: zInboxPriorityEnum,
     archivedAt: z.iso.datetime().nullable(),
     type: z.enum(['system']),
@@ -496,10 +514,13 @@ export const zInboxUnknown = z.object({
     userId: z.string().register(z.globalRegistry, {
         description: 'Recipient user identifier'
     }),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference key used for inbox grouping'
+    }),
     timestamp: z.string().register(z.globalRegistry, {
         description: 'Inbox event timestamp'
     }),
-    family: z.enum(['message']),
+    family: z.enum(['transaction']),
     priority: zInboxPriorityEnum,
     archivedAt: z.iso.datetime().nullable(),
     type: z.enum(['unknown']),
@@ -535,6 +556,9 @@ export const zInboxThumb = z.object({
     userId: z.string().register(z.globalRegistry, {
         description: 'Recipient user identifier'
     }),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference key used for inbox grouping'
+    }),
     timestamp: z.string().register(z.globalRegistry, {
         description: 'Inbox event timestamp'
     }),
@@ -559,6 +583,9 @@ export const zInboxFavourite = z.object({
     userId: z.string().register(z.globalRegistry, {
         description: 'Recipient user identifier'
     }),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference key used for inbox grouping'
+    }),
     timestamp: z.string().register(z.globalRegistry, {
         description: 'Inbox event timestamp'
     }),
@@ -581,6 +608,9 @@ export const zInboxUnfavourite = z.object({
     }),
     userId: z.string().register(z.globalRegistry, {
         description: 'Recipient user identifier'
+    }),
+    reference: z.string().register(z.globalRegistry, {
+        description: 'Normalized reference key used for inbox grouping'
     }),
     timestamp: z.string().register(z.globalRegistry, {
         description: 'Inbox event timestamp'


### PR DESCRIPTION
This PR adds the normalized inbox reference required by ZBA-284 and keeps the inbox family naming aligned with the actual transaction-related payloads.

- add required reference to inbox migration, DB schema, create schema, and query filtering
- populate reference from listingId in all current inbox producers
- rename transaction inbox family from message to transaction across contracts and producers
- add inbox tests for reference persistence plus family/reference filtering
- regenerate user SDK contracts and document in-place Docker Compose backfill steps

Validation:
- bun run sdk
- bun run typecheck (apps/server)
- bun run typecheck (repo root)
- bunx --bun vitest --run test/@user/inbox/fx/*.test.ts with required env in apps/server

Notes:
- local Docker Compose DB was updated in place for reference backfill and family rename
- older inbox rows needed a transaction join fallback because some historic buyer-message payloads lacked listingId