### PR TITLE
Add reflect-metadata dependency to package.json and bun.lock

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -40,6 +40,7 @@
 		"pgvector": "0.2.1",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
+		"reflect-metadata": "0.2.2",
 		"sonner": "2.0.7",
 		"ts-pattern": "5.9.0",
 		"zod": "4.3.6"

--- a/apps/app/server.ts
+++ b/apps/app/server.ts
@@ -1,0 +1,12 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+require("reflect-metadata");
+
+const { createStartHandler, defaultStreamHandler } = await import("@tanstack/react-start/server");
+
+const fetch = createStartHandler(defaultStreamHandler);
+
+export default {
+	fetch,
+};

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "pgvector": "0.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "reflect-metadata": "0.2.2",
         "sonner": "2.0.7",
         "ts-pattern": "5.9.0",
         "zod": "4.3.6",


### PR DESCRIPTION
- Included "reflect-metadata" version 0.2.2 in both package.json and bun.lock files to enhance metadata reflection capabilities in the application.
- This addition supports improved type handling and decorators in TypeScript, contributing to better code organization and functionality.