### PR TITLE
Update README and GitHub Actions for UAT environment

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,7 +4,7 @@ on:
     push:
         branches-ignore:
             - main
-            - staging
+            - uat
 
 concurrency:
     group: check
@@ -34,7 +34,7 @@ jobs:
     lint:
         name: Lint
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         steps:
             - uses: actions/checkout@v6.0.2
 
@@ -55,7 +55,7 @@ jobs:
     dc:
         name: Dependency Cruiser
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         steps:
             - uses: actions/checkout@v6.0.2
 
@@ -76,7 +76,7 @@ jobs:
     typecheck:
         name: Typecheck
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         steps:
             - uses: actions/checkout@v6.0.2
 
@@ -97,7 +97,7 @@ jobs:
     knip:
         name: Knip
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         steps:
             - uses: actions/checkout@v6.0.2
 
@@ -118,7 +118,7 @@ jobs:
     vitest:
         name: Vitest
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         steps:
             - uses: actions/checkout@v6.0.2
 
@@ -182,7 +182,7 @@ jobs:
     # e2e:
     #     name: Full-Stack Test
     #     runs-on: ubuntu-latest
-    #     environment: staging
+    #     environment: uat
     #     env:
     #         NITRO_PRESET: node_server
     #         SERVER_E2E: e2e

--- a/.github/workflows/uat.yaml
+++ b/.github/workflows/uat.yaml
@@ -1,11 +1,11 @@
-name: Staging Deploy
+name: UAT Deploy
 
 on:
     push:
-        branches: ["staging"]
+        branches: ["uat"]
 
 concurrency:
-    group: staging-deploy
+    group: uat-deploy
     cancel-in-progress: false
 
 permissions:
@@ -56,7 +56,7 @@ jobs:
     validate-env:
         name: Validate env variables
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         steps:
             - name: Check common environment variables
               run: |
@@ -106,7 +106,7 @@ jobs:
     build:
         name: Build
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         needs: [validate-env]
         steps:
             - uses: actions/checkout@v6.0.2
@@ -134,7 +134,7 @@ jobs:
     deploy:
         name: Deploy app to Vercel
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         needs: [build]
         steps:
             - name: Cache restore (app prebuilt)
@@ -167,7 +167,7 @@ jobs:
     cdn:
         name: Update CDN
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         needs: [build]
         steps:
             - name: Cache restore (app prebuilt)
@@ -196,7 +196,7 @@ jobs:
               uses: docker://rclone/rclone:1.73.2
               with:
                   args: >
-                      sync /github/workspace/.vercel/output/static/assets bunny:/staging/app/assets
+                      sync /github/workspace/.vercel/output/static/assets bunny:/uat/app/assets
                       --config /github/workspace/rclone.conf
                       --inplace
                       --sftp-set-modtime=false
@@ -213,7 +213,7 @@ jobs:
               uses: docker://rclone/rclone:1.73.2
               with:
                   args: >
-                      copy /github/workspace/.vercel/output/static bunny:/staging/app/
+                      copy /github/workspace/.vercel/output/static bunny:/uat/app/
                       --config /github/workspace/rclone.conf
                       --inplace
                       --include "/favicon*.ico"
@@ -233,7 +233,7 @@ jobs:
     migration:
         name: Run migrations
         runs-on: ubuntu-latest
-        environment: staging
+        environment: uat
         needs: [deploy]
         steps:
             - name: Trigger migrations endpoint

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The app scripts stay as plain `portless ...` commands. Start the shared HTTPS pr
 This README is the shared source of truth for environment variable naming and intent in the app.
 GitHub Actions environments are the source of truth only for which values are currently configured.
 Local sync source files live in `@env/*.json` and can be applied with `bun run env:sync <environment>`.
+The shared non-production environment is `uat`, so the canonical sync file is `@env/uat.json`.
 
 ### GitHub Actions only
 

--- a/cli/env-sync.ts
+++ b/cli/env-sync.ts
@@ -29,7 +29,7 @@ function printUsage(reason?: string, exitCode = 1): never {
 	console.error("Usage: bun run env:sync <environment> <vercel-project-id>");
 	console.error("");
 	console.error("Examples:");
-	console.error("  bun run env:sync staging prj_xxx");
+	console.error("  bun run env:sync uat prj_xxx");
 	console.error("  bun run env:sync production prj_xxx");
 
 	process.exit(exitCode);


### PR DESCRIPTION
- Added information about the shared non-production environment `uat` to the README.
- Updated GitHub Actions workflows to replace `staging` with `uat` for various jobs, ensuring the correct environment is used for linting, type checking, and deployment processes.
- Introduced a new workflow file `uat.yaml` for UAT deployment, including jobs for environment validation, building, deploying to Vercel, and updating the CDN.
- Modified the `env-sync` command usage example to reflect the new `uat` environment.