### PR TITLE
Refactor feed handling to remove locationId references

### DIFF
--- a/e2e/database/database-routing-a.test.ts
+++ b/e2e/database/database-routing-a.test.ts
@@ -13,7 +13,6 @@ test("registers the shared user in database A", async ({ page, database, db }) =
 
 		yield* feedCreateFx({
 			...getFeedDefaultCreate(`E2E feed A ${db}`),
-			locationId: null,
 			userId: seller.id,
 		});
 

--- a/e2e/database/database-routing-b.test.ts
+++ b/e2e/database/database-routing-b.test.ts
@@ -13,7 +13,6 @@ test("registers the shared user in database B", async ({ page, database, db }) =
 
 		yield* feedCreateFx({
 			...getFeedDefaultCreate(`E2E feed B ${db}`),
-			locationId: null,
 			userId: seller.id,
 		});
 

--- a/src/buyer/feed/server/db/withFeedSelectFx.ts
+++ b/src/buyer/feed/server/db/withFeedSelectFx.ts
@@ -22,7 +22,6 @@ export const withFeedSelectFx = Effect.fn("withFeedSelectFx")(function* ({
 		.select([
 			"f.id",
 			"f.userId",
-			"f.locationId",
 			"f.uploadId",
 			"f.type",
 			"f.name",

--- a/src/buyer/feed/server/fx/feedCreateFx.ts
+++ b/src/buyer/feed/server/fx/feedCreateFx.ts
@@ -8,7 +8,6 @@ import { KyselyContextFx } from "~/server/database/context/KyselyContextFx";
 import { tryDbFx } from "~/server/database/fx/tryDbFx";
 import { withTransactionFx } from "~/server/database/fx/withTransactionFx";
 import { ConflictErrorFx } from "~/server/error/ConflictErrorFx";
-import { locationFetchFx } from "~/session/location/server/fx/locationFetchFx";
 
 export namespace feedCreateFx {
 	export interface Props extends FeedCreateSchema.Type {
@@ -35,30 +34,6 @@ export const feedCreateFx = Effect.fn("feedCreateFx")(function* ({
 
 			const id = genId();
 			const now = dateContext.now();
-
-			if (data.locationId && !query.meta?.latLon) {
-				logger.trace("Binding locationId", {
-					locationId: data.locationId,
-				});
-
-				const location = yield* locationFetchFx({
-					where: {
-						id: data.locationId,
-					},
-				});
-
-				query.meta = {
-					...query.meta,
-					latLon: {
-						lat: location.lat,
-						lon: location.lon,
-					},
-				};
-
-				logger.trace("Updated query.meta", {
-					query,
-				});
-			}
 
 			yield* tryDbFx(
 				async () =>

--- a/src/buyer/feed/server/fx/feedPatchFx.ts
+++ b/src/buyer/feed/server/fx/feedPatchFx.ts
@@ -7,7 +7,6 @@ import type { FeedPatchSchema } from "~/buyer/feed/server/schema/FeedPatchSchema
 import { KyselyContextFx } from "~/server/database/context/KyselyContextFx";
 import { tryDbFx } from "~/server/database/fx/tryDbFx";
 import { withTransactionFx } from "~/server/database/fx/withTransactionFx";
-import { locationFetchFx } from "~/session/location/server/fx/locationFetchFx";
 
 export namespace feedPatchFx {
 	export interface Props extends FeedPatchSchema.Type {
@@ -36,43 +35,6 @@ export const feedPatchFx = Effect.fn("feedPatchFx")(function* ({
 				...query,
 				scope,
 			});
-
-			if (patch.locationId && !feed.query.meta?.latLon) {
-				logger.trace("Binding locationId", {
-					locationId: patch.locationId,
-				});
-
-				const location = yield* locationFetchFx({
-					where: {
-						id: patch.locationId,
-					},
-				});
-
-				patch.query = {
-					...patch.query,
-					meta: {
-						...patch.query?.meta,
-						latLon: {
-							lat: location.lat,
-							lon: location.lon,
-						},
-					},
-				};
-
-				logger.trace("Updated query.meta", {
-					query: patch.query,
-				});
-			}
-
-			if (patch.locationId === null) {
-				patch.query = {
-					...patch.query,
-					meta: {
-						...patch.query?.meta,
-						latLon: undefined,
-					},
-				};
-			}
 
 			yield* tryDbFx(async () =>
 				kysely

--- a/src/buyer/feed/server/schema/FeedCreateSchema.ts
+++ b/src/buyer/feed/server/schema/FeedCreateSchema.ts
@@ -8,9 +8,6 @@ export const FeedCreateSchema = z
 		name: z.string().min(1).meta({
 			description: "Name of the feed",
 		}),
-		locationId: z.string().nullish().meta({
-			description: "ID of the location associated with the feed",
-		}),
 		query: ListingQuerySchema,
 	})
 	.strip()

--- a/src/buyer/feed/server/tool/toolFeedCreate.ts
+++ b/src/buyer/feed/server/tool/toolFeedCreate.ts
@@ -58,8 +58,7 @@ Create a saved listing search for the current buyer from known query fields.
 Use only when the user wants to save search criteria. Do not invent the feed name, location, category, price range, or other listing query details.
 
 Hint:
-- If the user provides an address, normalize it and fill locationId
-- Resolve latLon from locationId and fill also query.meta.latLon
+- If the user provides an address, normalize it and fill query.meta.locationId
 - Pay attention to available fields in 'query' field, also in 'query.meta'
     `.trim(),
 	strict: true,

--- a/src/buyer/feed/ui/FeedEditor/Editor.tsx
+++ b/src/buyer/feed/ui/FeedEditor/Editor.tsx
@@ -37,6 +37,8 @@ export const Editor: FC<Editor.Props> = ({
 	children,
 	...props
 }) => {
+	const locationId = feed.query?.meta?.locationId;
+
 	return (
 		<Container
 			data-ui={"FeedEditor-[Container.content]"}
@@ -109,7 +111,7 @@ export const Editor: FC<Editor.Props> = ({
 				<LocationValue
 					_suspense={"I know"}
 					data-action={"edit feed location"}
-					locationId={feed.locationId}
+					locationId={locationId}
 					textLabel={translator.text("Feed location (label)")}
 					textEmpty={translator.text("Feed location not selected")}
 					textHint={translator.text("Feed location (hint)")}
@@ -120,7 +122,7 @@ export const Editor: FC<Editor.Props> = ({
 						/>
 					}
 					wrapperProps={{
-						"data-ui-tone": feed.locationId ? "neutral" : "secondary",
+						"data-ui-tone": locationId ? "neutral" : "secondary",
 					}}
 					onClick={() => onView("location")}
 				/>
@@ -128,7 +130,7 @@ export const Editor: FC<Editor.Props> = ({
 				<RangeValue
 					data-action={"edit feed range"}
 					range={feed.query?.filter?.range}
-					data-ui-disabled={!feed.query?.meta?.latLon}
+					data-ui-disabled={!locationId}
 					action={
 						<Icon
 							icon={ChevronRightIcon}

--- a/src/buyer/feed/ui/FeedEditor/patch/ListingSortSelect.tsx
+++ b/src/buyer/feed/ui/FeedEditor/patch/ListingSortSelect.tsx
@@ -9,12 +9,11 @@ import { uiSelectButton } from "~/common/ui/ui";
 
 export namespace ListingSortSelect {
 	export interface Props extends Omit<Container.Props, "onChange"> {
-		withGeo: boolean | undefined;
 		state: StateType.Simple<ListingSortSchema.Type[]>;
 	}
 }
 
-export const ListingSortSelect: FC<ListingSortSelect.Props> = ({ withGeo, state, ...props }) => {
+export const ListingSortSelect: FC<ListingSortSelect.Props> = ({ state, ...props }) => {
 	const sortKeyId = useId();
 
 	return (
@@ -33,7 +32,7 @@ export const ListingSortSelect: FC<ListingSortSelect.Props> = ({ withGeo, state,
 						"age",
 						"price",
 						"condition",
-						withGeo ? "geo" : undefined,
+						"geo",
 					] satisfies (ListingSortSchema.Field | undefined)[]
 				).filter(Boolean) as ListingSortSchema.Field[]
 			).map((sortValue) => {

--- a/src/buyer/feed/ui/FeedEditor/patch/LocationPatch.tsx
+++ b/src/buyer/feed/ui/FeedEditor/patch/LocationPatch.tsx
@@ -16,7 +16,9 @@ export namespace LocationPatch {
 
 export const LocationPatch: FC<LocationPatch.Props> = ({ feed, onSettled, onCancel, ...props }) => {
 	const patchMutation = withFeedQuery.usePatchMutation();
-	const [locationId, setLocationId] = useState<string | undefined | null>(feed.locationId);
+	const [locationId, setLocationId] = useState<string | undefined | null>(
+		feed.query?.meta?.locationId,
+	);
 
 	return (
 		<Container
@@ -44,7 +46,13 @@ export const LocationPatch: FC<LocationPatch.Props> = ({ feed, onSettled, onCanc
 								},
 							},
 							patch: {
-								locationId,
+								query: {
+									...feed.query,
+									meta: {
+										...feed.query?.meta,
+										locationId: locationId ?? undefined,
+									},
+								},
 							},
 						},
 						{

--- a/src/buyer/feed/ui/FeedEditor/patch/SortPatch.tsx
+++ b/src/buyer/feed/ui/FeedEditor/patch/SortPatch.tsx
@@ -17,7 +17,6 @@ export namespace SortPatch {
 export const SortPatch: FC<SortPatch.Props> = ({ feed, onSettled, onCancel, ...props }) => {
 	const patchMutation = withFeedQuery.usePatchMutation();
 	const [sort, setSort] = useState<ListingSortSchema.Type[]>(feed.query?.sort ?? []);
-	const withGeo = !!feed.query?.meta?.latLon;
 
 	return (
 		<Container
@@ -30,7 +29,6 @@ export const SortPatch: FC<SortPatch.Props> = ({ feed, onSettled, onCancel, ...p
 			{...props}
 		>
 			<ListingSortSelect
-				withGeo={withGeo}
 				state={{
 					value: sort,
 					set: setSort,

--- a/src/buyer/listing/server/db/withListingQueryBuilderFx.ts
+++ b/src/buyer/listing/server/db/withListingQueryBuilderFx.ts
@@ -107,17 +107,24 @@ export const withListingQueryBuilderFx = Effect.fn("withListingQueryBuilderFx")(
 		query = query.where("l.categoryId", "in", where.categoryIdIn) as TSelect;
 	}
 
-	if (meta?.latLon && where.range !== undefined) {
-		const { lon, lat } = meta.latLon;
+	if (meta?.locationId && where.range !== undefined) {
+		const locationId = meta.locationId;
 		const range = where.range * 1_000;
 
 		query = query.where(
-			(eb) =>
-				sql`ST_DWithin(
+			(eb) => {
+				const originGeoSelect = eb
+					.selectFrom("location as originLoc")
+					.select("originLoc.geo")
+					.where("originLoc.id", "=", locationId)
+					.limit(1);
+
+				return sql`ST_DWithin(
 					${eb.ref("loc.geo")},
-					ST_SetSRID(ST_MakePoint(${eb.val(lon)}, ${eb.val(lat)}), 4326)::geography,
+					${originGeoSelect},
 					${eb.val(range)}
-				)`,
+				)`;
+			},
 		) as TSelect;
 	}
 

--- a/src/buyer/listing/server/db/withListingSelectFx.ts
+++ b/src/buyer/listing/server/db/withListingSelectFx.ts
@@ -24,6 +24,7 @@ export const withListingSelectFx = Effect.fn("withListingSelectFx")(function* ({
 	meta,
 	hasExplicitCategory,
 }: withListingSelectFx.Props) {
+	const locationId = meta?.locationId;
 	const listingSourceSelect = yield* withListingSourceSelectFx({
 		userId,
 		sort,
@@ -66,21 +67,22 @@ export const withListingSelectFx = Effect.fn("withListingSelectFx")(function* ({
 		sql<string[] | null>`to_jsonb(${eb.ref("l.cons")})`.as("cons"),
 		eb
 			.case()
-			.when(sql.lit(meta?.latLon != null))
-			.then(
-				sql`
+			.when(sql.lit(locationId != null))
+			.then(() => {
+				const originGeoSelect = eb
+					.selectFrom("location as originLoc")
+					.select("originLoc.geo")
+					// biome-ignore lint/style/noNonNullAssertion: Check is already don, bro
+					.where("originLoc.id", "=", locationId!)
+					.limit(1);
+
+				return sql`
                         ST_Distance(
                             ${eb.ref("loc.geo")},
-                            ST_SetSRID(
-                                ST_MakePoint(
-                                    ${eb.val(meta?.latLon?.lon)},
-                                    ${eb.val(meta?.latLon?.lat)}
-                                ),
-                                4326
-                            )::geography
+                            ${originGeoSelect}
                         ) / 1000
-		            `,
-			)
+		            `;
+			})
 			.else(null)
 			.end()
 			.$castTo<number | null>()

--- a/src/buyer/listing/server/db/withListingSourceSelectFx.ts
+++ b/src/buyer/listing/server/db/withListingSourceSelectFx.ts
@@ -57,10 +57,10 @@ export const withListingSourceSelectFx = Effect.fn("withListingSourceSelectFx")(
 			.with("updatedAt", () => query.orderBy("l.updatedAt", item.order))
 			.with("expiresAt", () => query.orderBy("l.expiresAt", item.order))
 			.with("geo", () => {
-				if (!meta?.latLon) {
+				if (!meta?.locationId) {
 					return query;
 				}
-				const { lon, lat } = meta.latLon;
+				const locationId = meta.locationId;
 				const isDesc = item.order === "desc";
 				const sortOrder = isDesc ? "asc" : item.order;
 				/**
@@ -68,14 +68,34 @@ export const withListingSourceSelectFx = Effect.fn("withListingSourceSelectFx")(
 				 * For DESC (farthest-first), order by distance to the antipode ASC,
 				 * which is equivalent and keeps index usage.
 				 */
-				const sortLon = isDesc ? (lon >= 0 ? lon - 180 : lon + 180) : lon;
-				const sortLat = isDesc ? -lat : lat;
 
 				return query.orderBy(
-					(eb) =>
-						sql`${eb.ref("loc.geo")} <-> ST_SetSRID(ST_MakePoint(${eb.val(
-							sortLon,
-						)}, ${eb.val(sortLat)}), 4326)`,
+					(eb) => {
+						const originPointSelect = eb
+							.selectFrom("location as originLoc")
+							.select((originEb) =>
+								sql`ST_SetSRID(
+									ST_MakePoint(
+										case
+											when ${originEb.val(isDesc)} and ${originEb.ref("originLoc.lon")} >= 0 then ${originEb.ref("originLoc.lon")} - 180
+											when ${originEb.val(isDesc)} then ${originEb.ref("originLoc.lon")} + 180
+											else ${originEb.ref("originLoc.lon")}
+										end,
+										case
+											when ${originEb.val(isDesc)} then -${originEb.ref("originLoc.lat")}
+											else ${originEb.ref("originLoc.lat")}
+										end
+									),
+									4326
+								)`.as("point"),
+							)
+							.where("originLoc.id", "=", locationId)
+							.limit(1);
+
+						return sql`${eb.ref("loc.geo")} <-> (
+							${originPointSelect}
+						)`;
+					},
 					sortOrder,
 				);
 			})

--- a/src/buyer/listing/server/schema/ListingMetaSchema.ts
+++ b/src/buyer/listing/server/schema/ListingMetaSchema.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
-import { LatLonSchema } from "@/lib/common/location";
 
 export const ListingMetaSchema = z
 	.looseObject({
-		latLon: LatLonSchema.optional(),
+		locationId: z.string().min(1, "Location ID is required").optional().meta({
+			id: "ListingLocationId",
+			description: "Reference location used for listing geo targeting and distance sorting",
+		}),
 		feedId: z.string().min(1, "Feed ID is required").optional().meta({
 			id: "FeedId",
 			description: "Reference feed to do counts e.g. like is in favourites",
@@ -12,8 +14,7 @@ export const ListingMetaSchema = z
 	.strip()
 	.meta({
 		id: "ListingMeta",
-		description:
-			"Important metadata for e.g. location targeting of listings and related feedId.",
+		description: "Important metadata for listing location targeting and related feedId.",
 	});
 
 export type ListingMetaSchema = typeof ListingMetaSchema;

--- a/src/public/listing/server/db/withListingQueryBuilderFx.ts
+++ b/src/public/listing/server/db/withListingQueryBuilderFx.ts
@@ -98,17 +98,24 @@ export const withListingQueryBuilderFx = Effect.fn("withListingQueryBuilderFx")(
 		query = query.where("l.categoryId", "in", where.categoryIdIn) as TSelect;
 	}
 
-	if (meta?.latLon && where.range !== undefined) {
-		const { lon, lat } = meta.latLon;
+	if (meta?.locationId && where.range !== undefined) {
+		const locationId = meta.locationId;
 		const range = where.range * 1_000;
 
 		query = query.where(
-			(eb) =>
-				sql`ST_DWithin(
+			(eb) => {
+				const originGeoSelect = eb
+					.selectFrom("location as originLoc")
+					.select("originLoc.geo")
+					.where("originLoc.id", "=", locationId)
+					.limit(1);
+
+				return sql`ST_DWithin(
 					${eb.ref("loc.geo")},
-					ST_SetSRID(ST_MakePoint(${eb.val(lon)}, ${eb.val(lat)}), 4326)::geography,
+					${originGeoSelect},
 					${eb.val(range)}
-				)`,
+				)`;
+			},
 		) as TSelect;
 	}
 

--- a/src/public/listing/server/db/withListingSourceSelectFx.ts
+++ b/src/public/listing/server/db/withListingSourceSelectFx.ts
@@ -55,20 +55,40 @@ export const withListingSourceSelectFx = Effect.fn("withListingSourceSelectFx")(
 			.with("updatedAt", () => query.orderBy("l.updatedAt", item.order))
 			.with("expiresAt", () => query.orderBy("l.expiresAt", item.order))
 			.with("geo", () => {
-				if (!meta?.latLon) {
+				if (!meta?.locationId) {
 					return query;
 				}
-				const { lon, lat } = meta.latLon;
+				const locationId = meta.locationId;
 				const isDesc = item.order === "desc";
 				const sortOrder = isDesc ? "asc" : item.order;
-				const sortLon = isDesc ? (lon >= 0 ? lon - 180 : lon + 180) : lon;
-				const sortLat = isDesc ? -lat : lat;
 
 				return query.orderBy(
-					(eb) =>
-						sql`${eb.ref("loc.geo")} <-> ST_SetSRID(ST_MakePoint(${eb.val(
-							sortLon,
-						)}, ${eb.val(sortLat)}), 4326)`,
+					(eb) => {
+						const originPointSelect = eb
+							.selectFrom("location as originLoc")
+							.select((originEb) =>
+								sql`ST_SetSRID(
+									ST_MakePoint(
+										case
+											when ${originEb.val(isDesc)} and ${originEb.ref("originLoc.lon")} >= 0 then ${originEb.ref("originLoc.lon")} - 180
+											when ${originEb.val(isDesc)} then ${originEb.ref("originLoc.lon")} + 180
+											else ${originEb.ref("originLoc.lon")}
+										end,
+										case
+											when ${originEb.val(isDesc)} then -${originEb.ref("originLoc.lat")}
+											else ${originEb.ref("originLoc.lat")}
+										end
+									),
+									4326
+								)`.as("point"),
+							)
+							.where("originLoc.id", "=", locationId)
+							.limit(1);
+
+						return sql`${eb.ref("loc.geo")} <-> (
+							${originPointSelect}
+						)`;
+					},
 					sortOrder,
 				);
 			})

--- a/src/public/listing/server/schema/ListingMetaSchema.ts
+++ b/src/public/listing/server/schema/ListingMetaSchema.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
-import { LatLonSchema } from "@/lib/common/location";
 
 export const ListingMetaSchema = z
 	.looseObject({
-		latLon: LatLonSchema.optional(),
+		locationId: z.string().min(1, "Location ID is required").optional().meta({
+			id: "PublicListingLocationId",
+			description: "Reference location used for public listing geo targeting",
+		}),
 	})
 	.strip()
 	.meta({

--- a/src/server/@migrations/0013-feed.ts
+++ b/src/server/@migrations/0013-feed.ts
@@ -18,7 +18,6 @@ export const FeedMigration: Migration = {
 			.createTable("feed")
 			.addColumn("id", "text", (col) => col.primaryKey().notNull())
 			.addColumn("userId", "text", (col) => col.notNull())
-			.addColumn("locationId", "text")
 			.addColumn("uploadId", "text")
 			.addColumn("type", sql`feed_type_enum`, (col) => col.notNull())
 			.addColumn("name", "text", (col) => col.notNull())
@@ -35,17 +34,6 @@ export const FeedMigration: Migration = {
 					"id",
 				],
 				(c) => c.onDelete("cascade"),
-			)
-			.addForeignKeyConstraint(
-				"feed_[locationId]_fk",
-				[
-					"locationId",
-				],
-				"location",
-				[
-					"id",
-				],
-				(c) => c.onDelete("set null"),
 			)
 			.addForeignKeyConstraint(
 				"feed_[uploadId]_fk",
@@ -91,12 +79,6 @@ export const FeedMigration: Migration = {
 			CREATE INDEX "feed_[userId-createdAt]_idx"
 			ON "feed" ("userId", "createdAt" DESC);
 		`.execute(db);
-
-		await db.schema
-			.createIndex("feed_[locationId]_idx")
-			.on("feed")
-			.column("locationId")
-			.execute();
 
 		await db.schema.createIndex("feed_[uploadId]_idx").on("feed").column("uploadId").execute();
 	},

--- a/src/server/@system/seed/fx/core/seedCoreFeedFx.ts
+++ b/src/server/@system/seed/fx/core/seedCoreFeedFx.ts
@@ -54,8 +54,11 @@ export const seedCoreFeedFx = Effect.fn("seedCoreFeedFx")(function* ({
 								userId,
 								type: "user",
 								name: `seed-${genId()}-${i}`,
-								locationId: location?.id ?? null,
-								query: {},
+								query: {
+									meta: {
+										locationId: location?.id,
+									},
+								},
 							}).pipe(withSeedNowFx(withRandomPastDate()));
 						}),
 					);

--- a/src/server/@system/seed/fx/seedInteractionFx.ts
+++ b/src/server/@system/seed/fx/seedInteractionFx.ts
@@ -64,7 +64,6 @@ export const seedInteractionFx = Effect.fn("seedInteractionFx")(function* ({
 			type: "user",
 			name: `seed-interaction-${genId()}`,
 			query: {},
-			locationId: null,
 		})).id;
 
 	const listingCandidatesRaw = yield* tryDbFx(async () =>

--- a/src/server/database/@table/FeedTableSchema.ts
+++ b/src/server/database/@table/FeedTableSchema.ts
@@ -9,9 +9,6 @@ export const FeedTableSchema = z
 		userId: z.string().meta({
 			description: "ID of the user who created the feed",
 		}),
-		locationId: z.string().nullish().meta({
-			description: "ID of the location associated with the feed",
-		}),
 		uploadId: z.string().nullish().meta({
 			description:
 				"Hero image for this feed (usually selected from the listings in the feed)",

--- a/src/session/location/server/tool/toolLocationBrowse.ts
+++ b/src/session/location/server/tool/toolLocationBrowse.ts
@@ -1,5 +1,6 @@
 import { tool } from "@openai/agents";
 import { stringify } from "csv-stringify/sync";
+import { ofGoogleMap } from "@/lib/common/location";
 import { getRootLogger } from "~/common/log/getRootLogger";
 import { unsafeJsonSchema } from "~/server/openai/unsafeJsonSchema";
 import { locationAutocompleteFn } from "~/session/location/fn/locationAutocompleteFn";
@@ -49,6 +50,9 @@ or a location id. Return compact candidates; do not guess an id when multiple ca
 				address: item.address,
 				lat: item.lat,
 				lon: item.lon,
+				google: ofGoogleMap({
+					latLon: item,
+				}),
 			})),
 			{
 				header: true,
@@ -58,6 +62,7 @@ or a location id. Return compact candidates; do not guess an id when multiple ca
 					"address",
 					"lat",
 					"lon",
+					"google",
 				],
 			},
 		);

--- a/test/@buyer/listing/fx/listingDiscoveryFx/filters-buyer-state-location-and-scope.test.ts
+++ b/test/@buyer/listing/fx/listingDiscoveryFx/filters-buyer-state-location-and-scope.test.ts
@@ -124,10 +124,7 @@ describe("buyer listing discovery flow", () => {
 				range: 10,
 			};
 			const filteredMeta = {
-				latLon: {
-					lat: 50.075539,
-					lon: 14.4378,
-				},
+				locationId: listingDefaults.locationId,
 			};
 			const filtered = yield* listingCollectionFx({
 				userId: users.buyer.id,

--- a/test/@public/listing/fx/listingSearchFlowFx/filters-location-category-and-live-status.test.ts
+++ b/test/@public/listing/fx/listingSearchFlowFx/filters-location-category-and-live-status.test.ts
@@ -107,10 +107,7 @@ describe("public listing search flow", () => {
 				range: 10,
 			};
 			const meta = {
-				latLon: {
-					lat: 50.075539,
-					lon: 14.4378,
-				},
+				locationId: listingDefaults.locationId,
 			};
 			const collection = yield* listingCollectionFx({
 				scope: {},


### PR DESCRIPTION
- Removed locationId from various feed-related files, including tests, schemas, and database migrations, to streamline the data structure.
- Updated related functions and components to utilize query.meta.locationId instead, enhancing consistency across the application.
- Adjusted tests to reflect the changes in the feed structure, ensuring proper functionality without locationId.
- This refactor aims to simplify the codebase and improve clarity in how location data is managed within feeds.